### PR TITLE
feat: implement round descriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ export default function App() {
             </>
           )}
           <h2>Round {state.currentRound.number} of 6</h2>
+          {state.currentRound.description}
           <p>
             Capacity: {state.currentRound.capacity.available} /{' '}
             {state.currentRound.capacity.total}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,1 @@
 export const TOTAL_ROUNDS = 6;
-export const BASE_CAPACITY = 10;

--- a/src/state/effects/effects.ts
+++ b/src/state/effects/effects.ts
@@ -1,13 +1,5 @@
-import { findGameActionById } from './gameActions';
-import { Round } from './round';
-
-export type Effect = {
-  capacity: number;
-  title: string;
-  description?: string;
-};
-
-type GameEffect = (rounds: Round[]) => Effect | null;
+import { findGameActionById } from '../gameActions';
+import { GameEffect } from './types';
 
 export const gameEffectList: GameEffect[] = [
   function technicalDebtDrag(rounds) {

--- a/src/state/effects/helpers.ts
+++ b/src/state/effects/helpers.ts
@@ -1,0 +1,9 @@
+import { Effect, EFFECT_HIDDEN, VisibleEffect } from './types';
+
+export function isEffect(e: Effect | null): e is Effect {
+  return e !== null;
+}
+
+export function isVisibleEffect(e: Effect): e is VisibleEffect {
+  return e.title !== EFFECT_HIDDEN;
+}

--- a/src/state/effects/index.ts
+++ b/src/state/effects/index.ts
@@ -1,0 +1,12 @@
+import {
+  Effect as EffectT,
+  GameEffect as GameEffectT,
+  VisibleEffect as VisibleEffectT,
+} from './types';
+export type Effect = EffectT;
+export type GameEffect = GameEffectT;
+export type VisibleEffect = VisibleEffectT;
+
+export { EFFECT_HIDDEN } from './types';
+export { gameEffectList } from './effects';
+export { isEffect, isVisibleEffect } from './helpers';

--- a/src/state/effects/types.ts
+++ b/src/state/effects/types.ts
@@ -1,0 +1,16 @@
+import { Round } from '../round';
+export const EFFECT_HIDDEN = Symbol('EFFECT_HIDDEN');
+
+export type VisibleEffect = {
+  capacity: number;
+  title: string;
+  description?: string;
+};
+export type Effect =
+  | VisibleEffect
+  | {
+      capacity: number;
+      title: typeof EFFECT_HIDDEN;
+    };
+
+export type GameEffect = (rounds: Round[]) => Effect | null;

--- a/src/state/gameActions/gameActions.spec.ts
+++ b/src/state/gameActions/gameActions.spec.ts
@@ -3,8 +3,16 @@ import useAppState from '../useAppState';
 import { GameActionId } from './gameActions';
 
 /* disable game effect to only tests single actions */
-jest.mock('../effects', () => ({
+jest.mock('../effects/effects', () => ({
   gameEffectList: [],
+}));
+jest.mock('../roundDescriptions/roundDescriptions', () => ({
+  roundDescriptions: {
+    1: {
+      description: null,
+      effect: () => ({ capacity: 10 }),
+    },
+  },
 }));
 
 describe('GameActions', () => {

--- a/src/state/roundDescriptions/getRoundDescriptionEffects.ts
+++ b/src/state/roundDescriptions/getRoundDescriptionEffects.ts
@@ -1,0 +1,21 @@
+import { Effect } from '../effects';
+import { ClosedRound } from '../round';
+import { roundDescriptions } from './roundDescriptions';
+
+export function getRoundDescriptionEffects(pastRounds: ClosedRound[]) {
+  const currentRound = pastRounds.length;
+  const roundDescriptionEffects: (null | Effect)[] = [];
+
+  for (let i = 0; i <= currentRound; i++) {
+    const desc = roundDescriptions[i + 1];
+    if (!desc) {
+      continue;
+    }
+    const previousRounds = pastRounds.slice(0, i);
+    roundDescriptionEffects.push(
+      desc.effect?.(currentRound + 1, previousRounds) || null,
+    );
+  }
+
+  return roundDescriptionEffects;
+}

--- a/src/state/roundDescriptions/index.ts
+++ b/src/state/roundDescriptions/index.ts
@@ -1,0 +1,2 @@
+export { roundDescriptions } from './roundDescriptions';
+export { getRoundDescriptionEffects } from './getRoundDescriptionEffects';

--- a/src/state/roundDescriptions/roundDescriptions.spec.tsx
+++ b/src/state/roundDescriptions/roundDescriptions.spec.tsx
@@ -1,0 +1,36 @@
+import { renderHook, HookResult } from '@testing-library/react-hooks';
+import useAppState, { AppState } from '../useAppState';
+import { render, screen } from '@testing-library/react';
+
+/* disable game effect to only tests single actions */
+jest.mock('../effects/effects', () => ({
+  gameEffectList: [],
+}));
+
+describe('roundDescriptions and effects', () => {
+  let result: HookResult<ReturnType<typeof useAppState>>;
+
+  describe('round 1', () => {
+    it('starts with capacity 10/10 in round 1', () => {
+      result = renderHook(() => useAppState()).result;
+
+      const expectedCurrentRound: AppState['currentRound'] = expect.objectContaining(
+        {
+          capacity: {
+            total: 10,
+            available: 10,
+          },
+          number: 1,
+          activeEffects: [],
+        },
+      );
+
+      expect(result.current[0].currentRound).toEqual(expectedCurrentRound);
+
+      render(result.current[0].currentRound.description);
+      expect(
+        screen.getByText(/Welcome to the World’s Smallest Online Bookstore/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/state/roundDescriptions/roundDescriptions.tsx
+++ b/src/state/roundDescriptions/roundDescriptions.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement } from 'react';
+import { Effect, EFFECT_HIDDEN } from '../effects';
+import { ClosedRound } from '../round';
+
+export type RoundDescription = {
+  description: ReactElement;
+  effect?: (
+    roundNumber: number,
+    previousRounds: ClosedRound[],
+  ) => Effect | null;
+};
+
+/* Rounds are 1-indexed - 1 is the first round */
+export const roundDescriptions: { [key: string]: RoundDescription } = {
+  1: {
+    description: (
+      <>
+        <h2>Team, welcome to the World’s Smallest Online Bookstore</h2>
+        <p>
+          We hired you because you’re the best individuals in your respective
+          areas. Please remember that we’re Vulture Capital funded and we have
+          only a few months runway, so you must deliver. This first Sprint, the
+          company really needs you to prove that you can deliver a working …
+        </p>
+      </>
+    ),
+    effect: () => ({ capacity: 10, title: EFFECT_HIDDEN }),
+  },
+  3: {
+    description: (
+      <>
+        <h2>
+          We must go live with an early version of the product this round, for
+          CES
+        </h2>
+        <p>
+          Due to your limited productivity in past rounds, management are
+          prepared to offer some options to help you out. We will pay an extra
+          ‘4’ points for anything that helps. Another team member? Overtime?
+        </p>
+      </>
+    ),
+    effect: (roundNumber) => {
+      if (roundNumber === 3) {
+        return { capacity: 4, title: 'Management is paying overtime' };
+      }
+      return null;
+    },
+  },
+};

--- a/src/state/useAppState.spec.ts
+++ b/src/state/useAppState.spec.ts
@@ -1,22 +1,16 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import useAppState, { AppState } from './useAppState';
+import useAppState from './useAppState';
+
+jest.mock('./roundDescriptions/roundDescriptions', () => ({
+  roundDescriptions: {
+    1: {
+      description: null,
+      effect: () => ({ capacity: 10 }),
+    },
+  },
+}));
 
 describe('AppState', () => {
-  it('starts with capacity 10/10 in round 1', () => {
-    const { result } = renderHook(() => useAppState());
-
-    const expectedCurrentRound: AppState['currentRound'] = {
-      capacity: {
-        total: 10,
-        available: 10,
-      },
-      number: 1,
-      activeEffects: [],
-    };
-
-    expect(result.current[0].currentRound).toEqual(expectedCurrentRound);
-  });
-
   it('starts with no past rounds', () => {
     const { result } = renderHook(() => useAppState());
 


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="http://teamsgame.agilepainrelief.com/preview/round-descriptions"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

In oder to have top level descriptions in rounds that might also bring effects.

Side-Effects:
 - this way we can get rid of the BASE_CAPACITY constant since the first round
    will bring the initial capacity
- introduced hidden effects that only change capacity but are not visible in ui

fix https://github.com/mlevison/high-performance-teams-game/issues/7
ref https://github.com/mlevison/high-performance-teams-game/issues/6