### PR TITLE
fix: do not unmount current round when displaying rules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,30 +31,28 @@ export default function App() {
         </Tabs>
       </Header>
       <Content>
-        {tab === 'play' && (
-          <>
-            {state.currentRound.number > TOTAL_ROUNDS ? (
-              <Results storiesCompleted={state.result.storiesCompleted} />
-            ) : (
-              <Round
-                key={state.currentRound.number}
-                dispatch={dispatch}
-                currentRound={state.currentRound}
-                closeRound={closeRound}
-                overlayRef={overlayRef}
-                row1={
-                  <Actions
-                    overlay={overlayRef}
-                    currentRound={state.currentRound.number}
-                    availableGameActions={state.availableGameActions}
-                    dispatch={dispatch}
-                  />
-                }
-                row2={<Status {...state.currentRound} />}
-              />
-            )}
-          </>
-        )}
+        <div style={{ display: tab === 'play' ? 'block' : 'none' }}>
+          {state.currentRound.number > TOTAL_ROUNDS ? (
+            <Results storiesCompleted={state.result.storiesCompleted} />
+          ) : (
+            <Round
+              key={state.currentRound.number}
+              dispatch={dispatch}
+              currentRound={state.currentRound}
+              closeRound={closeRound}
+              overlayRef={overlayRef}
+              row1={
+                <Actions
+                  overlay={overlayRef}
+                  currentRound={state.currentRound.number}
+                  availableGameActions={state.availableGameActions}
+                  dispatch={dispatch}
+                />
+              }
+              row2={<Status {...state.currentRound} />}
+            />
+          )}
+        </div>
         {tab === 'rules' && <Rules />}
       </Content>
     </>


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/keep-play-state"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

the bug happened because the [round keeps the current view as internal state](https://github.com/mlevison/high-performance-teams-game/blob/b8c91c65fd42d052350cc7686950fe69104c752f/src/components/Round.tsx#L47)
previously we unmounted the round and this caused all internal state to be reset. Just hiding the UI is the easiest fix. (Another one would be to move the view state up into the App component but that would lead to a more complex API)