### PR TITLE
fix: apply selected boder and unavailable filter to icons

### DIFF
--- a/src/components/Actions/Actions.module.css
+++ b/src/components/Actions/Actions.module.css
@@ -42,7 +42,8 @@
 .action.disabled {
   color: var(--disabled-color);
 }
-.action.missingDep .actionImage {
+.action.missingDep .actionImage,
+.action.missingDep .actionIcon {
   filter: grayscale(100%);
 }
 
@@ -68,7 +69,8 @@
   filter: none;
 }
 
-.actionSelected .actionImage {
+.actionSelected .actionImage,
+.actionSelected .actionIcon {
   border-color: var(--primary-background-color);
 }
 

--- a/src/config/rounds/round2.tsx
+++ b/src/config/rounds/round2.tsx
@@ -33,7 +33,7 @@ export const round2: RoundDescription<Round2ActionId> = {
       effect: () => ({ capacity: 1 }),
     },
     GAME_ACTION_UNIT_TESTING: {
-      image: example,
+      icon: '🏗',
       type: 'ENGINEERING',
       name: 'Unit Testing',
       available: { requires: 'GAME_ACTION_BUILD_SERVER' },


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/highlight-icons"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

