### PR TITLE
fix: make round 4 capacity bump only last for 1 round

### DIFF
--- a/src/config/gameEffects/gameEffects.spec.ts
+++ b/src/config/gameEffects/gameEffects.spec.ts
@@ -1,5 +1,8 @@
+import { gameEffects as gameEffectsMock } from './gameEffects';
 import { getGame } from '../../lib/testHelpers';
 
+const { gameEffects } = jest.requireActual('./gameEffects');
+jest.mock('./gameEffects', () => ({ gameEffects: [] }));
 jest.mock('../rounds', () => {
   return {
     rounds: {
@@ -22,7 +25,16 @@ jest.mock('../rounds', () => {
 
 // TODO - we're going to need a mock here that silences the communication drag effect.
 describe('game effects', () => {
+  beforeEach(() => {
+    Object.keys(gameEffectsMock).forEach((key) => {
+      delete gameEffectsMock[key];
+    });
+  });
   describe('Drag Effect if the team makes no engineering improvement', () => {
+    beforeEach(() => {
+      gameEffectsMock.technicalDebtDrag = gameEffects.technicalDebtDrag;
+    });
+
     it('reduces capacity', () => {
       const game = getGame();
 
@@ -68,6 +80,10 @@ describe('game effects', () => {
   });
 
   describe('Drag Effect if the team makes no Communication improvement', () => {
+    beforeEach(() => {
+      gameEffectsMock.communicationDebtDrag = gameEffects.communicationDebtDrag;
+    });
+
     it('reduces capacity', () => {
       const game = getGame();
 

--- a/src/config/gameEffects/gameEffects.ts
+++ b/src/config/gameEffects/gameEffects.ts
@@ -1,7 +1,7 @@
 import { findGameActionById, GameEffect } from '../../state';
 
-export const gameEffects: GameEffect[] = [
-  function technicalDebtDrag(rounds) {
+export const gameEffects: { [key: string]: GameEffect } = {
+  technicalDebtDrag(rounds) {
     let roundsWithoutEngAction = 0;
 
     for (const round of rounds) {
@@ -31,7 +31,7 @@ export const gameEffects: GameEffect[] = [
       }`,
     };
   },
-  function communicationDebtDrag(rounds) {
+  communicationDebtDrag(rounds) {
     let roundsWithoutCommunicationAction = 0;
 
     for (const round of rounds) {
@@ -61,4 +61,4 @@ export const gameEffects: GameEffect[] = [
       }`,
     };
   },
-];
+};

--- a/src/config/rounds/round4.spec.tsx
+++ b/src/config/rounds/round4.spec.tsx
@@ -1,4 +1,4 @@
-import { AppState } from '../../state';
+import { AppState, isCapacityEffect } from '../../state';
 import { getGame } from '../../lib/testHelpers';
 
 /* disable irrelevant other rounds */
@@ -6,7 +6,6 @@ jest.mock('./index', () => ({
   rounds: {
     1: require('./round1').round1,
     4: require('./round4').round4,
-    5: require('./round5').round5,
   },
 }));
 /* disable game effect to only tests single actions */
@@ -36,43 +35,16 @@ describe('round 4', () => {
     expect(game.state.currentRound.activeEffects).toHaveLength(1);
     const round4Effect = game.state.currentRound.activeEffects[0];
 
-    /* TODO VSCode declares this be a syntax error */
+    if (!isCapacityEffect(round4Effect)) {
+      throw new Error('Expected effect of round 4 to be a capacity effect');
+    }
     expect(round4Effect.capacity).toBe(4);
     expect(round4Effect.title).toMatch(/Management is paying overtime/i);
 
     expect(game.state.currentRound.title).toMatch(/Go Live Soon/i);
-  });
 
-  describe('round 5', () => {
-    it('elminates round 4 capacity bump', () => {
-      const game = getGame();
-
-      game.nextRound();
-      game.nextRound();
-      game.nextRound();
-      game.nextRound();
-      const expectedCurrentRound: AppState['currentRound'] = expect.objectContaining(
-        {
-          capacity: {
-            total: 10,
-            available: 10,
-          },
-          number: 5,
-          activeEffects: expect.any(Array),
-        },
-      );
-
-      expect(game.state.currentRound).toEqual(expectedCurrentRound);
-      expect(game.state.currentRound.activeEffects).toHaveLength(1);
-      const round5Effect = game.state.currentRound.activeEffects[0];
-
-      // Should this be zero because we expect the capacity or -4 because we have to undo the effect of the previous round? I've assumed zero?
-      expect(round5Effect.capacity).toBe(0);
-      expect(round5Effect.title).toMatch(/Management is paying overtime/i);
-
-      expect(game.state.currentRound.title).toMatch(
-        /We're live and we have real Customers/i,
-      );
-    });
+    /* make sure bump only lasts for 1 round*/
+    game.nextRound();
+    expect(game.state.currentRound.activeEffects).toHaveLength(0);
   });
 });

--- a/src/config/rounds/round4.tsx
+++ b/src/config/rounds/round4.tsx
@@ -17,10 +17,15 @@ export const round4: RoundDescription<Round4ActionId> = {
       Overtime?
     </p>
   ),
-  effect: () => ({
-    capacity: 4,
-    title: 'Management is paying overtime',
-  }),
+  effect: (_, currentRound) => {
+    if (currentRound === 4) {
+      return {
+        capacity: 4,
+        title: 'Management is paying overtime',
+      };
+    }
+    return null;
+  },
   actions: {
     GAME_ACTION_INFORMAL_CROSS_TRAINING: {
       image: example,

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -57,7 +57,7 @@ export function getAllRoundEffects(pastRounds: ClosedRound[]) {
     return allEffects.concat(roundEffects);
   }, [] as (Effect | null)[]);
 
-  const activeGameEffects = gameEffects.map((gameEffect) => {
+  const activeGameEffects = Object.values(gameEffects).map((gameEffect) => {
     return gameEffect(pastRounds);
   });
 

--- a/src/state/rounds/getRoundEffects.ts
+++ b/src/state/rounds/getRoundEffects.ts
@@ -12,7 +12,7 @@ export function getRoundEffects(pastRounds: ClosedRound[]) {
       continue;
     }
     const previousRounds = pastRounds.slice(0, i);
-    roundEffects.push(desc.effect?.(previousRounds) || null);
+    roundEffects.push(desc.effect?.(previousRounds, currentRound + 1) || null);
   }
 
   return roundEffects;

--- a/src/state/rounds/index.ts
+++ b/src/state/rounds/index.ts
@@ -5,6 +5,6 @@ export { getRoundEffects } from './getRoundEffects';
 
 export type RoundDescription<T extends string> = RoundDescriptionT<T>;
 
-const round1Effect = rounds['1']?.effect?.([]);
+const round1Effect = rounds['1']?.effect?.([], 1);
 export const startCapacity =
   round1Effect && isCapacityEffect(round1Effect) ? round1Effect.capacity : 0;

--- a/src/state/rounds/types.ts
+++ b/src/state/rounds/types.ts
@@ -7,5 +7,5 @@ export type RoundDescription<T extends string> = {
   description: ReactNode;
   title: string;
   actions: GameActionList<T>;
-  effect?: (previousRounds: Round[]) => Effect | null;
+  effect?: (previousRounds: Round[], currentRound: number) => Effect | null;
 };


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/fix-round5-cap-bump"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

ref https://github.com/mlevison/high-performance-teams-game/issues/59