### PR TITLE
 prevent jumping of action images/icons when being selected

### DIFF
--- a/src/components/Actions/Actions.module.css
+++ b/src/components/Actions/Actions.module.css
@@ -58,7 +58,7 @@
   background-size: cover;
   width: 4rem;
   height: 4rem;
-  border: 3px solid var(--main-background-color);
+  border: 5px solid var(--main-background-color);
 }
 .actionIcon {
   font-size: 3.2rem;
@@ -71,7 +71,7 @@
 
 .actionSelected .actionImage,
 .actionSelected .actionIcon {
-  border: 5px solid var(--selected-action-color);
+  border-color: var(--selected-action-color);
 }
 
 .arrow {


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/not-jumping-actions"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

since the border had different dimensions when being selected and when not, the image jumped upon selection