### PR TITLE
refactor: simplify effects

### DIFF
--- a/src/components/EffectValue.tsx
+++ b/src/components/EffectValue.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { VisibleEffect, BaseEffect, isCapacityEffect } from '../state';
-import {
-  isGremlinChanceEffect,
-  isUserStoryChanceEffect,
-} from '../state/effects';
+import { VisibleEffect } from '../state';
 import styles from './EffectValue.module.css';
 
 type Props = {
-  effect: VisibleEffect<BaseEffect>;
+  effect: VisibleEffect;
 };
 
 export function Sign(props: { value: number; unit?: string }) {
@@ -21,31 +17,25 @@ export function Sign(props: { value: number; unit?: string }) {
 }
 
 export default function EffectValue(props: Props) {
-  if (isCapacityEffect(props.effect)) {
-    return (
-      <>
-        <Sign value={props.effect.capacityChange} /> Capacity
-      </>
-    );
-  }
-
-  if (isGremlinChanceEffect(props.effect)) {
-    return (
-      <>
-        <Sign value={props.effect.gremlinChange} unit="%" /> Chance of Gremlins
-        occurring
-      </>
-    );
-  }
-
-  if (isUserStoryChanceEffect(props.effect)) {
-    return (
-      <>
-        <Sign value={props.effect.userStoryChange} unit="%" /> Chance of User
-        Stories succeeding
-      </>
-    );
-  }
-
-  return null;
+  return (
+    <>
+      {props.effect.capacityChange !== undefined && (
+        <>
+          <Sign value={props.effect.capacityChange} /> Capacity
+        </>
+      )}
+      {props.effect.gremlinChange !== undefined && (
+        <>
+          <Sign value={props.effect.gremlinChange} unit="%" /> Chance of
+          Gremlins occurring
+        </>
+      )}
+      {props.effect.userStoryChange !== undefined && (
+        <>
+          <Sign value={props.effect.userStoryChange} unit="%" /> Chance of User
+          Stories succeeding
+        </>
+      )}
+    </>
+  );
 }

--- a/src/components/Round/Results.tsx
+++ b/src/components/Round/Results.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { GremlinId } from '../../config';
 import { START_USER_STORY_CHANCE, TOTAL_ROUNDS } from '../../constants';
-import {
-  AppState,
-  GameDispatch,
-  ClosedRound,
-  isUserStoryChanceEffect,
-} from '../../state';
+import { AppState, GameDispatch, ClosedRound } from '../../state';
 import Button from '../Button';
 import CapStoryChart from '../CapStoryChart';
 import styles from './Round.module.css';
@@ -21,7 +16,7 @@ type Props = {
 };
 export default function Results(props: Props) {
   const userStoryEffects = props.currentRound.activeEffects.filter(
-    isUserStoryChanceEffect,
+    (effect) => effect.userStoryChange !== undefined,
   );
 
   return (
@@ -32,8 +27,8 @@ export default function Results(props: Props) {
         <li>&nbsp;&nbsp;&nbsp;{START_USER_STORY_CHANCE}% base chance</li>
         {userStoryEffects.map((effect) => (
           <li key={effect.title}>
-            {effect.userStoryChange > 0 ? '+' : '-'}{' '}
-            {effect.userStoryChange.toString().replace(/^-/, '')}%{' '}
+            {effect.userStoryChange! > 0 ? '+' : '-'}{' '}
+            {effect.userStoryChange!.toString().replace(/^-/, '')}%{' '}
             {effect.title}
           </li>
         ))}

--- a/src/config/rounds/round1.tsx
+++ b/src/config/rounds/round1.tsx
@@ -24,16 +24,11 @@ export const round1: RoundDescription<Round1ActionId> = {
       needs you to prove that you can deliver a working …
     </p>
   ),
-  effect: () => [
-    {
-      title: EFFECT_HIDDEN,
-      capacityChange: START_CAPACITY,
-    },
-    {
-      title: EFFECT_HIDDEN,
-      userStoryChange: START_USER_STORY_CHANCE,
-    },
-  ],
+  effect: () => ({
+    title: EFFECT_HIDDEN,
+    capacityChange: START_CAPACITY,
+    userStoryChange: START_USER_STORY_CHANCE,
+  }),
   actions: {
     PROTECTED_FROM_OUTSIDE_DISTRACTION: {
       image: 'https://placekitten.com/100/100',

--- a/src/config/rounds/round4.spec.tsx
+++ b/src/config/rounds/round4.spec.tsx
@@ -1,4 +1,4 @@
-import { AppState, isCapacityEffect } from '../../state';
+import { AppState } from '../../state';
 import { getGame, testFutureCapacities } from '../../lib/testHelpers';
 
 /* disable irrelevant other rounds */
@@ -34,10 +34,6 @@ describe('round 4', () => {
     expect(game.state.currentRound).toEqual(expectedCurrentRound);
     expect(game.state.currentRound.activeEffects).toHaveLength(1);
     const round4Effect = game.state.currentRound.activeEffects[0];
-
-    if (!isCapacityEffect(round4Effect)) {
-      throw new Error('Expected effect of round 4 to be a capacity effect');
-    }
     expect(round4Effect.capacityChange).toBe(4);
     expect(round4Effect.title).toMatch(/Management is paying overtime/i);
 

--- a/src/lib/byProp.ts
+++ b/src/lib/byProp.ts
@@ -12,7 +12,7 @@ export function sumByProp<T extends object>(
 ): number {
   let sum = 0;
   objects.forEach((obj) => {
-    sum += (obj as any)[key];
+    sum += (obj as any)[key] || 0;
   });
   return sum;
 }

--- a/src/state/effects/helpers.ts
+++ b/src/state/effects/helpers.ts
@@ -1,43 +1,10 @@
-import {
-  CapacityEffect,
-  CAPACITY_CHANGE_KEY,
-  Effect,
-  GremlinChanceEffect,
-  GREMLIN_CHANGE_KEY,
-  UserStoryChanceEffect,
-  USER_STORY_CHANGE_KEY,
-  VisibleEffect,
-} from './types';
+import { Effect, VisibleEffect } from './types';
 import { EFFECT_HIDDEN } from '../../constants';
 
 export function isEffect(e: Effect | null): e is Effect {
   return e !== null;
 }
 
-export function isVisibleEffect<T extends Effect>(e: T): e is VisibleEffect<T> {
+export function isVisibleEffect(e: Effect): e is VisibleEffect {
   return e.title !== EFFECT_HIDDEN;
-}
-
-export function isCapacityEffect<T extends Effect>(
-  e: T,
-): e is CapacityEffect<T> {
-  return Object.getOwnPropertyNames(e).includes(CAPACITY_CHANGE_KEY);
-}
-
-export function isUserStoryChanceEffect<T extends Effect>(
-  e: T,
-): e is UserStoryChanceEffect<T> {
-  return Object.getOwnPropertyNames(e).includes(USER_STORY_CHANGE_KEY);
-}
-
-export function isGremlinChanceEffect<T extends Effect>(
-  e: T,
-): e is GremlinChanceEffect<T> {
-  return Object.getOwnPropertyNames(e).includes(GREMLIN_CHANGE_KEY);
-}
-
-export function isUserStoryOrGremlinChanceEffect<T extends Effect>(
-  effect: T,
-): effect is UserStoryChanceEffect<T> | GremlinChanceEffect<T> {
-  return isUserStoryChanceEffect(effect) || isGremlinChanceEffect(effect);
 }

--- a/src/state/effects/types.ts
+++ b/src/state/effects/types.ts
@@ -1,25 +1,6 @@
 import { GameRound } from '../round';
 import { EFFECT_HIDDEN } from '../../constants';
 
-export const GREMLIN_CHANGE_KEY = 'gremlinChange';
-export const CAPACITY_CHANGE_KEY = 'capacityChange';
-export const USER_STORY_CHANGE_KEY = 'userStoryChange';
-
-type GremlinChanceEffectProps = {
-  [GREMLIN_CHANGE_KEY]: number;
-  [CAPACITY_CHANGE_KEY]?: never;
-  [USER_STORY_CHANGE_KEY]?: never;
-};
-type CapacityEffectProps = {
-  [GREMLIN_CHANGE_KEY]?: never;
-  [CAPACITY_CHANGE_KEY]: number;
-  [USER_STORY_CHANGE_KEY]?: never;
-};
-type UserStoryChanceEffectProps = {
-  [CAPACITY_CHANGE_KEY]?: never;
-  [GREMLIN_CHANGE_KEY]?: never;
-  [USER_STORY_CHANGE_KEY]: number;
-};
 type InvisibleEffectProps = {
   title: typeof EFFECT_HIDDEN;
   description?: never;
@@ -29,19 +10,12 @@ type VisibleEffectProps = {
   description?: string;
 };
 export type EffectDescription = InvisibleEffectProps | VisibleEffectProps;
-export type BaseEffect =
-  | CapacityEffectProps
-  | UserStoryChanceEffectProps
-  | GremlinChanceEffectProps;
-
-export type InvisibleEffect<T extends BaseEffect> = T & InvisibleEffectProps;
-export type VisibleEffect<T extends BaseEffect> = T & VisibleEffectProps;
-export type CapacityEffect<T extends EffectDescription> = T &
-  CapacityEffectProps;
-export type UserStoryChanceEffect<T extends EffectDescription> = T &
-  UserStoryChanceEffectProps;
-export type GremlinChanceEffect<T extends EffectDescription> = T &
-  GremlinChanceEffectProps;
-
+export type BaseEffect = {
+  gremlinChange?: number;
+  capacityChange?: number;
+  userStoryChange?: number;
+};
+export type InvisibleEffect = BaseEffect & InvisibleEffectProps;
+export type VisibleEffect = BaseEffect & VisibleEffectProps;
 export type Effect = BaseEffect & EffectDescription;
 export type GameEffect = (rounds: GameRound[]) => Effect[] | Effect | null;

--- a/src/state/gremlins.ts
+++ b/src/state/gremlins.ts
@@ -2,7 +2,7 @@ import { sumByProp } from 'lib';
 import { random } from 'lib/random';
 import { ReactElement } from 'react';
 import { GameActionId, GremlinId, gremlins } from '../config';
-import { Effect, isGremlinChanceEffect } from './effects';
+import { Effect } from './effects';
 import { GameState, getAllEffects } from './game';
 import { GameRound } from './round';
 
@@ -27,10 +27,8 @@ export function rollGremlin(state: GameState): GremlinId | null {
     ...gremlin,
   }));
 
-  const gremlinChanceEffects = getAllEffects(state).filter(
-    isGremlinChanceEffect,
-  );
-  const gremlinChance = sumByProp(gremlinChanceEffects, 'gremlinChange');
+  const allEffects = getAllEffects(state);
+  const gremlinChance = sumByProp(allEffects, 'gremlinChange');
 
   if (random() * 100 > gremlinChance) {
     return null;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -16,6 +16,5 @@ export {
   isGameActionWithImage,
   UNIQUE_ACTION,
 } from './gameActions';
-export { isCapacityEffect, isUserStoryChanceEffect } from './effects';
 export { default as useAppState } from './useAppState';
 export { gameReducer, INITIAL_STATE } from './game';

--- a/src/state/round.ts
+++ b/src/state/round.ts
@@ -6,15 +6,7 @@ import {
   getCost as getActionCost,
   getEffects,
 } from './gameActions';
-import {
-  BaseEffect,
-  Effect,
-  isEffect,
-  isGremlinChanceEffect,
-  isUserStoryChanceEffect,
-  isVisibleEffect,
-  VisibleEffect,
-} from './effects';
+import { Effect, isEffect, isVisibleEffect, VisibleEffect } from './effects';
 import { getGremlin, GremlinDescription } from './gremlins';
 import { ReactNode } from 'react';
 import { GameAction } from './gameActions/types';
@@ -30,7 +22,7 @@ export type AppRound = {
   number: number;
   title?: string;
   gremlin?: GremlinDescription & {
-    effect: VisibleEffect<BaseEffect>[];
+    effect: VisibleEffect[];
   };
   description?: ReactNode;
   selectedGameActions: GameAction[];
@@ -40,7 +32,7 @@ export type AppRound = {
   };
   gremlinChance: number;
   userStoryChance: number;
-  activeEffects: VisibleEffect<BaseEffect>[];
+  activeEffects: VisibleEffect[];
 };
 
 export function createRound(gremlin: GremlinId | null): GameRound {
@@ -75,10 +67,7 @@ export function closeRound(state: GameState): ClosedGameRound {
   const effects = getAllEffects(state);
   const storiesAttempted = getCapacity(effects) - getCosts(state.currentRound);
 
-  const chance = sumByProp(
-    effects.filter(isUserStoryChanceEffect),
-    'userStoryChange',
-  );
+  const chance = sumByProp(effects, 'userStoryChange');
 
   return {
     ...state.currentRound,
@@ -105,10 +94,7 @@ export function deriveAppRound(
   const effects = getAllEffects(state, finishedActionIds);
   const roundCapacity = orZero(getCapacity(effects));
   const visibleEffects = effects.filter(isVisibleEffect);
-  const totalUserStoryChance = sumByProp(
-    effects.filter(isUserStoryChanceEffect),
-    'userStoryChange',
-  );
+  const totalUserStoryChance = sumByProp(effects, 'userStoryChange');
   const costs = getCosts(state.currentRound);
   const capacityAvailable = orZero(roundCapacity - costs);
   const currentRoundNumber = state.pastRounds.length + 1;
@@ -142,10 +128,7 @@ export function deriveAppRound(
       available: capacityAvailable,
       total: roundCapacity,
     },
-    gremlinChance: sumByProp(
-      effects.filter(isGremlinChanceEffect),
-      'gremlinChange',
-    ),
+    gremlinChance: sumByProp(effects, 'gremlinChange'),
     userStoryChance: totalUserStoryChance,
     activeEffects: visibleEffects,
   };

--- a/src/state/rounds/getRoundEffects.ts
+++ b/src/state/rounds/getRoundEffects.ts
@@ -1,4 +1,4 @@
-import { Effect, isEffect, isGremlinChanceEffect } from '../effects';
+import { Effect, isEffect } from '../effects';
 import { rounds } from '../../config';
 import { GameState } from 'state/game';
 
@@ -33,8 +33,14 @@ export function getRoundEffects(
   const nextRoundEffects = Array.isArray(nextRoundEffect)
     ? nextRoundEffect
     : [nextRoundEffect];
+  const nextRoundGremlinEffects = nextRoundEffects
+    .filter((effect) => effect.gremlinChange !== undefined)
+    .map((effect) => ({
+      ...effect,
+      /* Next rounds userStoryChange and capacityChange must not be active this round */
+      userStoryChange: undefined,
+      capacityChange: undefined,
+    }));
 
-  return roundEffects
-    .filter(isEffect)
-    .concat(nextRoundEffects.filter(isGremlinChanceEffect));
+  return roundEffects.filter(isEffect).concat(nextRoundGremlinEffects);
 }


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/multi-purpose-effects"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

Feels a bit painful to remove this but I agree that it probably is a lot easier to understand and maintain this way.