### PR TITLE
re-introduce GameActionId and GremlinId typings

### DIFF
--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import { App } from './App';
 import { AppState, UNIQUE_ACTION, ClosedRound, GameConfig } from '../state';
 import { createInitialState, useAppState } from '../lib';
-import { emptyRound } from '../lib/testHelpers';
+import { round } from '../lib/testHelpers';
 
 jest.mock('../lib/useAppState');
 jest.mock('recharts');
@@ -32,7 +32,7 @@ const BASE_STATE: AppState = {
 
 const BASE_CONFIG: GameConfig = {
   initialScores: {},
-  rounds: [emptyRound(), emptyRound(), emptyRound(), emptyRound()],
+  rounds: [round(), round(), round(), round()],
   trailingRounds: 0,
   gameEffects: {},
   gremlins: {},

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { App } from './App';
 import { AppState, UNIQUE_ACTION, ClosedRound, GameConfig } from '../state';
-import { INITIAL_STATE, useAppState } from '../lib';
+import { createInitialState, useAppState } from '../lib';
 import { emptyRound } from '../lib/testHelpers';
 
-jest.mock('../lib');
+jest.mock('../lib/useAppState');
 jest.mock('recharts');
 
+const INITIAL_STATE = createInitialState();
 const BASE_STATE: AppState = {
   ui: {
     review: false,

--- a/src/app/App.spec.tsx
+++ b/src/app/App.spec.tsx
@@ -31,6 +31,7 @@ const BASE_STATE: AppState = {
 };
 
 const BASE_CONFIG: GameConfig = {
+  initialScores: {},
   rounds: [emptyRound(), emptyRound(), emptyRound(), emptyRound()],
   trailingRounds: 0,
   gameEffects: {},

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,7 +19,7 @@ import {
   Log,
 } from './components';
 import {
-  INITIAL_STATE,
+  createInitialState,
   GAME_STATE_OK,
   InitialStateWithStatus,
   restartGame,
@@ -32,8 +32,8 @@ import {
 type Props = { initialState: GameState; config: GameConfig };
 export function App(props: Props) {
   const [state, closeRound, rollGremlin, link, dispatch] = useAppState(
-    props.initialState,
     props.config,
+    props.initialState,
   );
   const {
     rounds: [firstRound],
@@ -51,7 +51,7 @@ export function App(props: Props) {
     ];
   }, [firstRound]);
   const [tab, setTab] = useState<'play' | 'rules' | 'log'>(
-    props.initialState === INITIAL_STATE ? 'rules' : 'play',
+    props.initialState.log.length === 0 ? 'rules' : 'play',
   );
 
   return (
@@ -185,7 +185,7 @@ export function App(props: Props) {
 
 export default function OutdatedStateWarning(props: {
   initialState: InitialStateWithStatus;
-  config: GameConfig;
+  config: GameConfig<any>;
 }) {
   const version = useVersion();
   const [initialState, setInitialState] = useState(props.initialState);
@@ -255,7 +255,10 @@ export default function OutdatedStateWarning(props: {
         </Button>
         <Button
           onClick={() =>
-            setInitialState({ state: INITIAL_STATE, status: GAME_STATE_OK })
+            setInitialState({
+              state: createInitialState(),
+              status: GAME_STATE_OK,
+            })
           }
           primary
         >

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -185,7 +185,7 @@ export function App(props: Props) {
 
 export default function OutdatedStateWarning(props: {
   initialState: InitialStateWithStatus;
-  config: GameConfig<any>;
+  config: GameConfig<any, any>;
 }) {
   const version = useVersion();
   const [initialState, setInitialState] = useState(props.initialState);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import type { GameState, GameConfig, Effect } from '../state';
+import React, { useState } from 'react';
+import type { GameState, GameConfig } from '../state';
 import {
   Results,
   FinalResults,
@@ -25,7 +25,6 @@ import {
   restartGame,
   useVersion,
   saveToLocalStorage,
-  sumByProp,
   useAppState,
 } from '../lib';
 
@@ -35,21 +34,9 @@ export function App(props: Props) {
     props.config,
     props.initialState,
   );
-  const {
-    rounds: [firstRound],
-  } = props.config;
   const interactiveRounds = props.config.rounds.length;
   const totalRounds = interactiveRounds + props.config.trailingRounds;
-  const [initialCapacity, initialUserStoryChance] = useMemo(() => {
-    const initialEffects = ([] as Effect[]).concat(
-      (!firstRound.effect ? null : firstRound.effect([], 1)) || [],
-    );
 
-    return [
-      sumByProp(initialEffects, 'capacityChange'),
-      sumByProp(initialEffects, 'userStoryChange'),
-    ];
-  }, [firstRound]);
   const [tab, setTab] = useState<'play' | 'rules' | 'log'>(
     props.initialState.log.length === 0 ? 'rules' : 'play',
   );
@@ -147,7 +134,9 @@ export function App(props: Props) {
                     <Row>
                       <Status
                         {...state.currentRound}
-                        startCapacity={initialCapacity}
+                        startCapacity={
+                          props.config.initialScores.capacityChange || 0
+                        }
                       />
                     </Row>
                   </Rows>
@@ -161,7 +150,9 @@ export function App(props: Props) {
                   dispatch={dispatch}
                   closeRound={closeRound}
                   rollGremlin={rollGremlin}
-                  initialUserStoryChance={initialUserStoryChance}
+                  initialUserStoryChance={
+                    props.config.initialScores.userStoryChange || 0
+                  }
                   totalRounds={totalRounds}
                   interactiveRounds={interactiveRounds}
                 />

--- a/src/app/components/Round/Results.tsx
+++ b/src/app/components/Round/Results.tsx
@@ -5,10 +5,7 @@ import Button from '../Button';
 import CapStoryChart from '../CapStoryChart';
 import styles from './Round.module.css';
 
-type Props = {
-  ui: AppState['ui'];
-  pastRounds: AppState['pastRounds'];
-  currentRound: AppState['currentRound'];
+type Props = Pick<AppState, 'ui' | 'pastRounds' | 'currentRound'> & {
   closeRound: () => ClosedRound;
   rollGremlin: () => string | null;
   dispatch: GameDispatch;

--- a/src/app/components/Round/Round.tsx
+++ b/src/app/components/Round/Round.tsx
@@ -2,10 +2,8 @@ import React, { ReactElement } from 'react';
 import type { AppState } from '../../../state';
 import styles from './Round.module.css';
 
-type Props = {
-  currentRound: AppState['currentRound'];
+type Props = Pick<AppState, 'currentRound' | 'ui'> & {
   totalRounds: number;
-  ui: AppState['ui'];
   welcome: ReactElement;
   actions: ReactElement;
   results?: ReactElement;

--- a/src/config/gameEffects/gameEffects.spec.ts
+++ b/src/config/gameEffects/gameEffects.spec.ts
@@ -2,7 +2,7 @@ import { gameEffects as gameEffectsMock } from './gameEffects';
 import { getGame, testFutureRounds } from '../../lib/testHelpers';
 
 jest.mock('../../state/rounds/getRoundEffects', () => ({
-  getRoundEffects: () => [{ capacityChange: 10, userStoryChange: 30 }],
+  getRoundEffects: () => [],
 }));
 const { gameEffects } = jest.requireActual('./gameEffects');
 jest.mock('./gameEffects', () => ({ gameEffects: [] }));

--- a/src/config/gameEffects/gameEffects.spec.ts
+++ b/src/config/gameEffects/gameEffects.spec.ts
@@ -1,44 +1,28 @@
-import { gameEffects as gameEffectsMock } from './gameEffects';
-import { getGame, testFutureRounds } from '../../lib/testHelpers';
-
-jest.mock('../../state/rounds/getRoundEffects', () => ({
-  getRoundEffects: () => [],
-}));
-const { gameEffects } = jest.requireActual('./gameEffects');
-jest.mock('./gameEffects', () => ({ gameEffects: [] }));
-jest.mock('../rounds', () => {
-  return {
-    rounds: [
-      {
-        actions: {
-          BUILD_SERVER: {
-            type: 'ENGINEERING',
-            cost: 2,
-          },
-          WORKING_AGREEMENTS: {
-            type: 'COMMUNICATION',
-            cost: 2,
-          },
-        },
-        effect: () => ({ capacityChange: 10 }),
-      },
-    ],
-  };
-});
+import { gameEffects } from './gameEffects';
+import {
+  round,
+  getGame,
+  testFutureRounds,
+  action,
+  config,
+} from '../../lib/testHelpers';
 
 describe('game effects', () => {
-  beforeEach(() => {
-    Object.keys(gameEffectsMock).forEach((key) => {
-      delete gameEffectsMock[key];
-    });
-  });
   describe('Drag Effect if the team makes no engineering improvement', () => {
-    beforeEach(() => {
-      gameEffectsMock.technicalDebtDrag = gameEffects.technicalDebtDrag;
-    });
+    const dragEffectConfig = config(
+      {
+        rounds: [
+          round({ actions: { BUILD_SERVER: action({ type: 'ENGINEERING' }) } }),
+        ],
+        gameEffects: {
+          technicalDebtDrag: gameEffects.technicalDebtDrag,
+        },
+      },
+      6,
+    );
 
     it('reduces capacity', () => {
-      const game = getGame();
+      const game = getGame(dragEffectConfig);
 
       // Precondition
       expect(game.state.currentRound.number).toEqual(1);
@@ -53,7 +37,7 @@ describe('game effects', () => {
     });
 
     it('stops reducing capacity when team added a BuildServer', () => {
-      const game = getGame();
+      const game = getGame(dragEffectConfig);
       // precondition
       expect(game.state.currentRound.number).toEqual(1);
 
@@ -68,12 +52,22 @@ describe('game effects', () => {
   });
 
   describe('Drag Effect if the team makes no Communication improvement', () => {
-    beforeEach(() => {
-      gameEffectsMock.communicationDebtDrag = gameEffects.communicationDebtDrag;
-    });
+    const dragEffectConfig = config(
+      {
+        rounds: [
+          round({
+            actions: { WORKING_AGREEMENTS: action({ type: 'COMMUNICATION' }) },
+          }),
+        ],
+        gameEffects: {
+          communicationDebtDrag: gameEffects.communicationDebtDrag,
+        },
+      },
+      6,
+    );
 
     it('reduces capacity', () => {
-      const game = getGame();
+      const game = getGame(dragEffectConfig);
 
       // Precondition
       expect(game.state.currentRound.number).toEqual(1);
@@ -88,7 +82,7 @@ describe('game effects', () => {
     });
 
     it('stops reducing capacity when team added a Working Agreement', () => {
-      const game = getGame();
+      const game = getGame(dragEffectConfig);
 
       // Ideally Stated as a precondition
       expect(game.state.currentRound.number).toEqual(1);

--- a/src/config/gameEffects/gameEffects.ts
+++ b/src/config/gameEffects/gameEffects.ts
@@ -1,9 +1,12 @@
 import type { GameEffect } from '../../state';
 import type { GameActionId } from '../rounds';
+import type { GremlinId } from '../gremlins';
 import { rounds as roundConfigs } from '../rounds';
 import { findGameActionById } from '../../lib';
 
-export const gameEffects: { [key: string]: GameEffect<GameActionId> } = {
+export const gameEffects: {
+  [key: string]: GameEffect<GameActionId, GremlinId>;
+} = {
   technicalDebtDrag(rounds) {
     let roundsWithoutEngAction = 0;
 

--- a/src/config/gameEffects/gameEffects.ts
+++ b/src/config/gameEffects/gameEffects.ts
@@ -1,8 +1,9 @@
+import type { GameEffect } from '../../state';
+import type { GameActionId } from '../rounds';
 import { rounds as roundConfigs } from '../rounds';
 import { findGameActionById } from '../../lib';
-import type { GameEffect } from '../../state';
 
-export const gameEffects: { [key: string]: GameEffect } = {
+export const gameEffects: { [key: string]: GameEffect<GameActionId> } = {
   technicalDebtDrag(rounds) {
     let roundsWithoutEngAction = 0;
 

--- a/src/config/gremlins/gremlins.spec.ts
+++ b/src/config/gremlins/gremlins.spec.ts
@@ -3,19 +3,16 @@ import {
   getGame,
   testCurrentRound,
   testFutureRounds,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 import { gremlins } from './gremlins';
+import { rounds } from '../rounds';
 
-/* Disable round, game and action effects */
-jest.mock('../../state/rounds/getRoundEffects', () => ({
-  getRoundEffects: () => [],
-}));
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
-jest.mock('../../state/gameActions/getEffects', () => ({
-  getEffects: () => [],
-}));
+const gremlinTestConfig = config({
+  gremlins,
+  rounds: defuseRounds(rounds),
+});
 
 describe('Gremlins', () => {
   describe('emergency on another team', () => {
@@ -31,7 +28,7 @@ describe('Gremlins', () => {
     });
 
     it('reduces capacity by 3 for 3 rounds', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_EMERGENCY_ON_OTHER_TEAM');
       testCurrentRound(game, { capacityChange: -3, userStoryChange: 0 });
@@ -44,7 +41,7 @@ describe('Gremlins', () => {
     });
 
     it('reduces capacity by 3 for 2 rounds when team is protected by outside distractions', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('PROTECTED_FROM_OUTSIDE_DISTRACTION');
       game.nextRound('GREMLIN_EMERGENCY_ON_OTHER_TEAM');
@@ -57,7 +54,7 @@ describe('Gremlins', () => {
     });
 
     it('reduces capacity by 2 for 3 rounds when team had informal cross training', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('CROSS_SKILLING');
       game.nextRound('GREMLIN_EMERGENCY_ON_OTHER_TEAM');
@@ -71,7 +68,7 @@ describe('Gremlins', () => {
     });
 
     it('reduces capacity by 1 for 2 rounds when team has all protective actions', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('CROSS_SKILLING');
       game.selectAction('EXTERNAL_CROSS_TRAINING');
@@ -88,7 +85,7 @@ describe('Gremlins', () => {
 
   describe('Management yells at a team member', () => {
     it('reduces capacity by 2 ', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_MANAGEMENT_YELLS');
       testCurrentRound(game, { capacityChange: -2, userStoryChange: 0 });
@@ -100,7 +97,7 @@ describe('Gremlins', () => {
     });
 
     it('has less effect on capacity when team is protected by outside distractions', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('PROTECTED_FROM_OUTSIDE_DISTRACTION');
       game.nextRound('GREMLIN_MANAGEMENT_YELLS');
@@ -128,7 +125,7 @@ describe('Gremlins', () => {
 
   describe('Team Member not pulling their weight', () => {
     it('reduces capacity by 2 ', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_NOT_PULLING_THEIR_WEIGHT');
       testCurrentRound(game, { capacityChange: -2, userStoryChange: 0 });
@@ -140,7 +137,7 @@ describe('Gremlins', () => {
     });
 
     it('has effect reduced by 1 if ScrumMaster conducts one on ones', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('ONE_ON_ONES');
       game.nextRound('GREMLIN_NOT_PULLING_THEIR_WEIGHT');
@@ -153,7 +150,7 @@ describe('Gremlins', () => {
     });
 
     it('has effect reduced by 1 if the team works on Cross Skilling', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('CROSS_SKILLING');
       game.nextRound('GREMLIN_NOT_PULLING_THEIR_WEIGHT');
@@ -166,7 +163,7 @@ describe('Gremlins', () => {
     });
 
     it('has effect reduce by only 1 if both One on Ones and Cross Skilling', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('ONE_ON_ONES');
       game.nextRound('GREMLIN_NOT_PULLING_THEIR_WEIGHT');
@@ -181,7 +178,7 @@ describe('Gremlins', () => {
 
   describe('Team Member consistently late or misses Daily Scrum', () => {
     it('reduces capacity by 1 ', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_NOT_AT_DAILY_SCRUM');
       testCurrentRound(game, { capacityChange: -1, userStoryChange: 0 });
@@ -192,7 +189,7 @@ describe('Gremlins', () => {
       ]);
     });
     it('has effect reduced to 0 if ScrumMaster conducts one on ones', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('ONE_ON_ONES');
       game.nextRound('GREMLIN_NOT_AT_DAILY_SCRUM');
@@ -204,7 +201,7 @@ describe('Gremlins', () => {
     });
 
     it('has effect reduced to 0 if Working Agreements in effect', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('WORKING_AGREEMENTS');
       game.nextRound('GREMLIN_NOT_AT_DAILY_SCRUM');
@@ -218,7 +215,7 @@ describe('Gremlins', () => {
 
   describe('New Story from PO MidSprint ', () => {
     it('reduces capacity by 2 and userStorySuccessChance by 10 goes away one round', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
       advanceGameToRound(game, 2);
 
       game.nextRound('GREMLIN_NEW_STORY_MID_SPRINT');
@@ -230,7 +227,7 @@ describe('Gremlins', () => {
     });
 
     it('has reduced effect on capacity when team does Product Backlog refinement', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('BACKLOG_REFINEMENT');
       game.nextRound('GREMLIN_NEW_STORY_MID_SPRINT');
@@ -242,7 +239,7 @@ describe('Gremlins', () => {
     });
 
     it('has reduced effect on capacity when team does Story Mapping to maintain a good Strategic view', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('STORY_MAPPING_OR_OTHER');
       game.nextRound('GREMLIN_NEW_STORY_MID_SPRINT');
@@ -254,7 +251,7 @@ describe('Gremlins', () => {
     });
 
     it('has no effect on capacity when team does Product Backlog refinement and Story Mapping', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('BACKLOG_REFINEMENT');
       game.selectAction('STORY_MAPPING_OR_OTHER');
@@ -268,7 +265,7 @@ describe('Gremlins', () => {
   });
   describe('Messy Code Found', () => {
     it('Unreadable code has a -ve effect on speed since we have to spend time on rereading it.', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_UNREADABLE_CODE');
       testCurrentRound(game, { capacityChange: -2, userStoryChange: 0 });
@@ -279,7 +276,7 @@ describe('Gremlins', () => {
       ]);
     });
     it('has effect reduced if Pair Programming is done', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('PAIR_PROGRAMMING');
       game.nextRound('GREMLIN_UNREADABLE_CODE');
@@ -290,7 +287,7 @@ describe('Gremlins', () => {
       ]);
     });
     it('has effect reduced if TDD is done', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('TEST_DRIVEN_DEVELOPMENT');
       game.nextRound('GREMLIN_UNREADABLE_CODE');
@@ -301,7 +298,7 @@ describe('Gremlins', () => {
       ]);
     });
     it('has no effect if TDD and Pair Programming is done', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('TEST_DRIVEN_DEVELOPMENT');
       game.selectAction('PAIR_PROGRAMMING');
@@ -316,7 +313,7 @@ describe('Gremlins', () => {
 
   describe('Product Backlog is a Mess ', () => {
     it('reduces capacity by 1 and userStorySuccessChance by 20 goes away one round', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
       advanceGameToRound(game, 2);
 
       game.nextRound('GREMLIN_PRODUCT_BACKLOG_MESS');
@@ -328,7 +325,7 @@ describe('Gremlins', () => {
     });
 
     it('has reduced effect on capacity when team does Product Backlog refinement', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('BACKLOG_REFINEMENT');
       game.nextRound('GREMLIN_PRODUCT_BACKLOG_MESS');
@@ -340,7 +337,7 @@ describe('Gremlins', () => {
     });
 
     it('has reduced effect on capacity when team does Story Mapping to maintain a good Strategic view', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('STORY_MAPPING_OR_OTHER');
       game.nextRound('GREMLIN_PRODUCT_BACKLOG_MESS');
@@ -352,7 +349,7 @@ describe('Gremlins', () => {
     });
 
     it('has no effect on capacity when team does Product Backlog refinement and Story Mapping', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('WORK_WITH_PO_LIMIT_PB_SIZE');
       game.nextRound('GREMLIN_PRODUCT_BACKLOG_MESS');
@@ -366,7 +363,7 @@ describe('Gremlins', () => {
 
   describe('Skip a Retro', () => {
     it('reduces capacity by -1 per round', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_SKIP_RETRO');
       // no effect in the current round since the damage is in the future
@@ -381,7 +378,7 @@ describe('Gremlins', () => {
     });
 
     it('avoided if the agenda is changed', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('IMPROVE_RETROSPECTIVES_CHANGE_AGENDA');
       game.nextRound('GREMLIN_SKIP_RETRO');
@@ -397,7 +394,7 @@ describe('Gremlins', () => {
     });
 
     it('avoided if Retrospectives implement Concrete actions', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.selectAction('IMPROVE_RETROSPECTIVES_CONCRETE_ACTIONS');
       game.nextRound('GREMLIN_SKIP_RETRO');
@@ -413,7 +410,7 @@ describe('Gremlins', () => {
     });
 
     it('If improvements are implemented later they still help', () => {
-      const game = getGame();
+      const game = getGame(gremlinTestConfig);
 
       game.nextRound('GREMLIN_SKIP_RETRO');
       // no effect in the current round since the damage is in the future

--- a/src/config/gremlins/gremlins.spec.ts
+++ b/src/config/gremlins/gremlins.spec.ts
@@ -8,7 +8,7 @@ import { gremlins } from './gremlins';
 
 /* Disable round, game and action effects */
 jest.mock('../../state/rounds/getRoundEffects', () => ({
-  getRoundEffects: () => [{ capacityChange: 10, userStoryChange: 30 }],
+  getRoundEffects: () => [],
 }));
 jest.mock('../gameEffects', () => ({
   gameEffects: [],

--- a/src/config/gremlins/gremlins.tsx
+++ b/src/config/gremlins/gremlins.tsx
@@ -2,7 +2,17 @@ import React from 'react';
 import type { GameActionId } from '../rounds';
 import type { GremlinList } from '../../state';
 
-export const gremlins: GremlinList<GameActionId> = {
+export type GremlinId =
+  | 'GREMLIN_MANAGEMENT_YELLS'
+  | 'GREMLIN_EMERGENCY_ON_OTHER_TEAM'
+  | 'GREMLIN_NOT_PULLING_THEIR_WEIGHT'
+  | 'GREMLIN_NOT_AT_DAILY_SCRUM'
+  | 'GREMLIN_NEW_STORY_MID_SPRINT'
+  | 'GREMLIN_UNREADABLE_CODE'
+  | 'GREMLIN_PRODUCT_BACKLOG_MESS'
+  | 'GREMLIN_SKIP_RETRO';
+
+export const gremlins: GremlinList<GremlinId, GameActionId> = {
   GREMLIN_MANAGEMENT_YELLS: {
     name: 'Management yells at a team member in public',
     probability: () => 10,

--- a/src/config/gremlins/gremlins.tsx
+++ b/src/config/gremlins/gremlins.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import type { GameActionId } from '../rounds';
 import type { GremlinList } from '../../state';
 
-export const gremlins: GremlinList = {
+export const gremlins: GremlinList<GameActionId> = {
   GREMLIN_MANAGEMENT_YELLS: {
     name: 'Management yells at a team member in public',
     probability: () => 10,

--- a/src/config/gremlins/index.ts
+++ b/src/config/gremlins/index.ts
@@ -1,1 +1,2 @@
+export type { GremlinId } from './gremlins';
 export { gremlins } from './gremlins';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,12 +1,14 @@
-import type { GameConfig } from '../state/game';
+import type { GameConfig } from '../state';
 import type { GameActionId } from './rounds';
+import type { GremlinId } from './gremlins';
 import { rounds } from './rounds';
 import { gremlins } from './gremlins';
 import { gameEffects } from './gameEffects';
 
 export type { GameActionId } from './rounds';
+export type { GremlinId } from './gremlins';
 
-export const config: GameConfig<GameActionId> = {
+export const config: GameConfig<GameActionId, GremlinId> = {
   rounds,
   gremlins,
   gameEffects,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,10 +1,12 @@
 import type { GameConfig } from '../state/game';
-
+import type { GameActionId } from './rounds';
 import { rounds } from './rounds';
 import { gremlins } from './gremlins';
 import { gameEffects } from './gameEffects';
 
-export const config: GameConfig = {
+export type { GameActionId } from './rounds';
+
+export const config: GameConfig<GameActionId> = {
   rounds,
   gremlins,
   gameEffects,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,9 +8,19 @@ import { gameEffects } from './gameEffects';
 export type { GameActionId } from './rounds';
 export type { GremlinId } from './gremlins';
 
+const INITIAL_CAPACITY = 10;
+const INITIAL_USER_STORY_CHANCE = 30;
+const INITIAL_GREMLIN_CHANCE = 0;
+const TRAILING_ROUNDS = 6;
+
 export const config: GameConfig<GameActionId, GremlinId> = {
+  initialScores: {
+    capacityChange: INITIAL_CAPACITY,
+    userStoryChange: INITIAL_USER_STORY_CHANCE,
+    gremlinChange: INITIAL_GREMLIN_CHANCE,
+  },
   rounds,
   gremlins,
   gameEffects,
-  trailingRounds: 6,
+  trailingRounds: TRAILING_ROUNDS,
 };

--- a/src/config/rounds/index.ts
+++ b/src/config/rounds/index.ts
@@ -1,3 +1,6 @@
+import type { RoundDescription as Rd } from '../../state';
+import type { GremlinId } from '../gremlins';
+
 import { round1, Round1ActionId } from './round1';
 import { round2, Round2ActionId } from './round2';
 import { round3, Round3ActionId } from './round3';
@@ -15,6 +18,12 @@ export type GameActionId =
   | Round5ActionId
   | Round6ActionId
   | Round7ActionId;
+
+export type RoundDescription<RoundActionId extends string> = Rd<
+  RoundActionId,
+  GameActionId,
+  GremlinId
+>;
 
 export const rounds = [
   round1,

--- a/src/config/rounds/index.ts
+++ b/src/config/rounds/index.ts
@@ -1,11 +1,20 @@
-import { round1 } from './round1';
-import { round2 } from './round2';
-import { round3 } from './round3';
-import { round4 } from './round4';
-import { round5 } from './round5';
-import { round6 } from './round6';
-import { round7 } from './round7';
+import { round1, Round1ActionId } from './round1';
+import { round2, Round2ActionId } from './round2';
+import { round3, Round3ActionId } from './round3';
+import { round4, Round4ActionId } from './round4';
+import { round5, Round5ActionId } from './round5';
+import { round6, Round6ActionId } from './round6';
+import { round7, Round7ActionId } from './round7';
 import { round8 } from './round8';
+
+export type GameActionId =
+  | Round1ActionId
+  | Round2ActionId
+  | Round3ActionId
+  | Round4ActionId
+  | Round5ActionId
+  | Round6ActionId
+  | Round7ActionId;
 
 export const rounds = [
   round1,

--- a/src/config/rounds/round1.spec.tsx
+++ b/src/config/rounds/round1.spec.tsx
@@ -1,21 +1,19 @@
+import { rounds } from './index';
 import {
   getGame,
+  config,
   testCurrentRound,
   testFutureRounds,
+  defuseRounds,
 } from '../../lib/testHelpers';
 
-/* disable all other rounds */
-jest.mock('./index', () => ({
-  rounds: [require('./round1').round1],
-}));
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+const testConfig = config({
+  rounds: [rounds[0], ...defuseRounds(rounds).slice(1)],
+});
 
 describe('round 1', () => {
   it('starts with capacity 10/10 and 30% userStoryChance in round 1', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
 
     // Since the base capacity and userStory chance are embedded in the test helper we just pass in the change
     testCurrentRound(game, {
@@ -28,7 +26,7 @@ describe('round 1', () => {
   describe('actions', () => {
     describe('Teams on same floor', () => {
       it('increases capacity over many rounds', () => {
-        const game = getGame();
+        const game = getGame(testConfig);
 
         game.selectAction('TEAMS_ON_SAME_FLOOR');
         game.nextRound();
@@ -47,7 +45,7 @@ describe('round 1', () => {
 
     describe('Protected from Outside Distraction', () => {
       it('increases the chance user-stories succeed', () => {
-        const game = getGame();
+        const game = getGame(testConfig);
 
         game.selectAction('PROTECTED_FROM_OUTSIDE_DISTRACTION');
         testCurrentRound(game, { capacityChange: 0, userStoryChange: 10 });
@@ -63,7 +61,7 @@ describe('round 1', () => {
 
     describe('Working Agreements', () => {
       it('increases capacity, but have no effect on User Story Success', () => {
-        const game = getGame();
+        const game = getGame(testConfig);
 
         game.selectAction('WORKING_AGREEMENTS');
         testCurrentRound(game, { capacityChange: 0, userStoryChange: 0 });
@@ -80,7 +78,7 @@ describe('round 1', () => {
 
     describe('Clarify Product Vision', () => {
       it('increases UserStory success and has no effect on capacity', () => {
-        const game = getGame();
+        const game = getGame(testConfig);
 
         game.selectAction('CLARIFY_PRODUCT_VISION');
         testCurrentRound(game, { capacityChange: 0, userStoryChange: 10 });

--- a/src/config/rounds/round1.tsx
+++ b/src/config/rounds/round1.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
-export const round1: RoundDescription = {
+export type Round1ActionId =
+  | 'PROTECTED_FROM_OUTSIDE_DISTRACTION'
+  | 'CLARIFY_PRODUCT_VISION'
+  | 'WORKING_AGREEMENTS'
+  | 'BUILD_SERVER'
+  | 'TEAMS_ON_SAME_FLOOR';
+
+export const round1: RoundDescription<Round1ActionId, GameActionId> = {
   title: 'Team, welcome to the World’s Smallest Online Bookstore',
   description: (
     <p>

--- a/src/config/rounds/round1.tsx
+++ b/src/config/rounds/round1.tsx
@@ -19,12 +19,6 @@ export const round1: RoundDescription<Round1ActionId> = {
       needs you to prove that you can deliver a working Bookstore soon.
     </p>
   ),
-  effect: () => ({
-    title: false,
-    capacityChange: 10,
-    userStoryChange: 30,
-    gremlinChange: 0,
-  }),
   actions: {
     PROTECTED_FROM_OUTSIDE_DISTRACTION: {
       image: 'https://placekitten.com/100/100',

--- a/src/config/rounds/round1.tsx
+++ b/src/config/rounds/round1.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round1ActionId =
@@ -10,7 +9,7 @@ export type Round1ActionId =
   | 'BUILD_SERVER'
   | 'TEAMS_ON_SAME_FLOOR';
 
-export const round1: RoundDescription<Round1ActionId, GameActionId> = {
+export const round1: RoundDescription<Round1ActionId> = {
   title: 'Team, welcome to the World’s Smallest Online Bookstore',
   description: (
     <p>

--- a/src/config/rounds/round2.spec.tsx
+++ b/src/config/rounds/round2.spec.tsx
@@ -1,22 +1,24 @@
+import { rounds } from './index';
 import {
   advanceGameToRound,
   getGame,
   testCurrentRound,
   testFutureRounds,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
-  rounds: [require('./round1').round1, require('./round2').round2],
-}));
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+const testConfig = config({
+  rounds: [
+    ...defuseRounds(rounds.slice(0, 1)),
+    rounds[1],
+    ...defuseRounds(rounds.slice(2)),
+  ],
+});
 
 describe('round2', () => {
   it('does not enable gremlins', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
 
     testFutureRounds(game, [
       { capacityChange: 0, gremlinChange: 0, userStoryChange: 0 },
@@ -31,7 +33,7 @@ describe('round2', () => {
 describe('round 2 Actions', () => {
   describe('Unit Testing', () => {
     it('is only available if the BuildServer was implemented', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 2);
       expect(game.state.currentRound.number).toEqual(2);
 
@@ -43,7 +45,7 @@ describe('round 2 Actions', () => {
     });
 
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
 
       game.selectAction('BUILD_SERVER');
       game.nextRound();
@@ -63,7 +65,7 @@ describe('round 2 Actions', () => {
 
   describe('Remote Avatars', () => {
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
 
       game.selectAction('REMOTE_TEAM_AVATARS');
       testCurrentRound(game, { capacityChange: 0, userStoryChange: 0 });
@@ -81,7 +83,7 @@ describe('round 2 Actions', () => {
 
   describe('Eliminate Long Lived Feature Branches', () => {
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 2);
       expect(game.state.currentRound.number).toEqual(2);
 
@@ -101,7 +103,7 @@ describe('round 2 Actions', () => {
 
   describe('Social Time', () => {
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 2);
       expect(game.state.currentRound.number).toEqual(2);
 
@@ -121,7 +123,7 @@ describe('round 2 Actions', () => {
 
   describe('Problem Solving Bonus', () => {
     it('increases capacity now at first but harms it in the future', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 2);
       expect(game.state.currentRound.number).toEqual(2);
 
@@ -138,7 +140,7 @@ describe('round 2 Actions', () => {
 
   describe('Product Backlog Refinement', () => {
     it('increases User Story Success, but have no effect on increases capacity', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 2);
       expect(game.state.currentRound.number).toEqual(2);
 

--- a/src/config/rounds/round2.tsx
+++ b/src/config/rounds/round2.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round2ActionId =
@@ -13,7 +12,7 @@ export type Round2ActionId =
 
 export const BR_USER_STORY_CHANGE = 15;
 
-export const round2: RoundDescription<Round2ActionId, GameActionId> = {
+export const round2: RoundDescription<Round2ActionId> = {
   title: 'Failed Expectations',
   description: (
     <p>

--- a/src/config/rounds/round2.tsx
+++ b/src/config/rounds/round2.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
+export type Round2ActionId =
+  | 'REMOTE_TEAM_AVATARS'
+  | 'ELIMINATE_LONG_LIVED_FEATURE_BRANCHES'
+  | 'UNIT_TESTING'
+  | 'SOCIAL_TIME'
+  | 'PROBLEM_SOLVING_BONUS'
+  | 'BACKLOG_REFINEMENT';
+
 export const BR_USER_STORY_CHANGE = 15;
 
-export const round2: RoundDescription = {
+export const round2: RoundDescription<Round2ActionId, GameActionId> = {
   title: 'Failed Expectations',
   description: (
     <p>

--- a/src/config/rounds/round3.spec.tsx
+++ b/src/config/rounds/round3.spec.tsx
@@ -1,26 +1,24 @@
+import { rounds } from './index';
 import {
   getGame,
   testFutureRounds,
   testCurrentRound,
   advanceGameToRound,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
+const testConfig = config({
   rounds: [
-    require('./round1').round1,
-    require('../../lib/testHelpers').emptyRound(),
-    require('./round3').round3,
+    ...defuseRounds(rounds.slice(0, 2)),
+    rounds[2],
+    ...defuseRounds(rounds.slice(3)),
   ],
-}));
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+});
 
 describe('round 3', () => {
   it('increases gremlinChance to 50', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
 
     game.nextRound();
     testFutureRounds(game, [
@@ -36,7 +34,7 @@ describe('round 3', () => {
 describe('round 3 Actions', () => {
   describe('Refactoring', () => {
     it('is only available if the BuildServer was implemented', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 
@@ -48,7 +46,7 @@ describe('round 3 Actions', () => {
     });
 
     it('increases capacity , but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 
@@ -66,7 +64,7 @@ describe('round 3 Actions', () => {
   });
   describe('Story Mapping or other Strategic tools', () => {
     it('is only available if the Clarify Product Vision was implemented', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
 
       expect(game.availableActionIds).not.toContain('');
 
@@ -82,28 +80,26 @@ describe('round 3 Actions', () => {
     });
 
     it('has an effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       game.selectAction('CLARIFY_PRODUCT_VISION');
       game.nextRound();
       game.selectAction('STORY_MAPPING_OR_OTHER');
 
       // StoryMapping Improves by 10% and the change is permanent.
-      //   Test is for +20% since we account for CLARIFY_PRODUCT_VISION as well
-      testCurrentRound(game, { capacityChange: 0, userStoryChange: 20 });
-
+      testCurrentRound(game, { capacityChange: 0, userStoryChange: 10 });
       testFutureRounds(game, [
-        { capacityChange: 0, userStoryChange: 20 },
-        { capacityChange: 0, userStoryChange: 20 },
-        { capacityChange: 0, userStoryChange: 20 },
-        { capacityChange: 0, userStoryChange: 20 },
-        { capacityChange: 0, userStoryChange: 20 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 10 },
       ]);
     });
   });
 
   describe('Observe People + Relationships', () => {
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 
@@ -122,7 +118,7 @@ describe('round 3 Actions', () => {
 
   describe('One on Ones', () => {
     it('no effect on capacity or User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 
@@ -141,7 +137,7 @@ describe('round 3 Actions', () => {
 
   describe('Pair Programming', () => {
     it('increases capacity, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 
@@ -158,7 +154,7 @@ describe('round 3 Actions', () => {
   });
   describe('Improve Retrospective', () => {
     it('increases capacity', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 3);
       expect(game.state.currentRound.number).toEqual(3);
 

--- a/src/config/rounds/round3.tsx
+++ b/src/config/rounds/round3.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round3ActionId =
@@ -11,7 +10,7 @@ export type Round3ActionId =
   | 'STORY_MAPPING_OR_OTHER'
   | 'REFACTORING';
 
-export const round3: RoundDescription<Round3ActionId, GameActionId> = {
+export const round3: RoundDescription<Round3ActionId> = {
   title: 'Work Harder',
   description: (
     <p>

--- a/src/config/rounds/round3.tsx
+++ b/src/config/rounds/round3.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
-export const round3: RoundDescription = {
+export type Round3ActionId =
+  | 'IMPROVE_RETROSPECTIVES_CHANGE_AGENDA'
+  | 'OBSERVE_PEOPLE_AND_RELATIONSHIPS'
+  | 'ONE_ON_ONES'
+  | 'PAIR_PROGRAMMING'
+  | 'STORY_MAPPING_OR_OTHER'
+  | 'REFACTORING';
+
+export const round3: RoundDescription<Round3ActionId, GameActionId> = {
   title: 'Work Harder',
   description: (
     <p>

--- a/src/config/rounds/round4.spec.tsx
+++ b/src/config/rounds/round4.spec.tsx
@@ -1,29 +1,25 @@
+import { rounds } from './index';
 import {
   advanceGameToRound,
   getGame,
   testCurrentRound,
   testFutureRounds,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
+const testConfig = config({
   rounds: [
-    require('./round1').round1,
-    require('../../lib/testHelpers').emptyRound(),
-    require('./round3').round3,
-    require('./round4').round4,
+    ...defuseRounds(rounds.slice(0, 3)),
+    rounds[3],
+    ...defuseRounds(rounds.slice(4)),
   ],
-}));
-
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+});
 
 describe('round 4', () => {
   describe('Test Driven Development', () => {
     it('is only available if refactoring was implemented', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
 
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
@@ -36,7 +32,7 @@ describe('round 4', () => {
     });
 
     it('is hard to learn but increases capacity later, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
 
@@ -44,21 +40,20 @@ describe('round 4', () => {
       game.nextRound();
       game.selectAction('TEST_DRIVEN_DEVELOPMENT');
 
-      // all these tests need to take into account that Refactoring already had +1 effect
-      testCurrentRound(game, { capacityChange: 1, userStoryChange: 0 });
+      testCurrentRound(game, { capacityChange: 0, userStoryChange: 0 });
 
       testFutureRounds(game, [
+        { capacityChange: 0, userStoryChange: 0 },
         { capacityChange: 1, userStoryChange: 0 },
         { capacityChange: 2, userStoryChange: 0 },
         { capacityChange: 3, userStoryChange: 0 },
-        { capacityChange: 4, userStoryChange: 0 },
-        { capacityChange: 4, userStoryChange: 0 },
+        { capacityChange: 3, userStoryChange: 0 },
       ]);
     });
   });
   describe('Cross Skilling', () => {
     it('is hard to learn but increases capacity later, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
 
@@ -78,7 +73,7 @@ describe('round 4', () => {
 
   describe('New Tester', () => {
     it('sometimes helps speed up a team', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
 
@@ -98,7 +93,7 @@ describe('round 4', () => {
 
   describe('Outside Course to learn testing', () => {
     it('is hard to learn but increases capacity later, but have no effect on User Story Success', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
 
@@ -117,7 +112,7 @@ describe('round 4', () => {
 
   describe('Personal Productivity Bonus', () => {
     it('increases User Story Success now harms Capacity later.', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       expect(game.state.currentRound.number).toEqual(4);
 
@@ -139,7 +134,7 @@ describe('round 4', () => {
 
   describe('Limit WIP', () => {
     it('Slows us down at first but eventually speeds us up', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       game.selectAction('LIMIT_WIP');
 

--- a/src/config/rounds/round4.tsx
+++ b/src/config/rounds/round4.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
-export const round4: RoundDescription = {
+export type Round4ActionId =
+  | 'CROSS_SKILLING'
+  | 'EXTERNAL_CROSS_TRAINING'
+  | 'PERSONAL_PRODUCTIVITY_BONUS'
+  | 'NEW_TESTER'
+  | 'TEST_DRIVEN_DEVELOPMENT'
+  | 'LIMIT_WIP';
+
+export const round4: RoundDescription<Round4ActionId, GameActionId> = {
   title: 'Team is Bottlenecked',
   description: (
     <p>

--- a/src/config/rounds/round4.tsx
+++ b/src/config/rounds/round4.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round4ActionId =
@@ -11,7 +10,7 @@ export type Round4ActionId =
   | 'TEST_DRIVEN_DEVELOPMENT'
   | 'LIMIT_WIP';
 
-export const round4: RoundDescription<Round4ActionId, GameActionId> = {
+export const round4: RoundDescription<Round4ActionId> = {
   title: 'Team is Bottlenecked',
   description: (
     <p>

--- a/src/config/rounds/round5.spec.tsx
+++ b/src/config/rounds/round5.spec.tsx
@@ -1,31 +1,25 @@
+import { rounds } from './index';
 import {
   getGame,
   testFutureRounds,
   advanceGameToRound,
   testCurrentRound,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
-import { BR_USER_STORY_CHANGE } from './round2';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
+const testConfig = config({
   rounds: [
-    require('./round1').round1,
-    require('./round2').round2,
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('./round5').round5,
+    ...defuseRounds(rounds.slice(0, 4)),
+    rounds[4],
+    ...defuseRounds(rounds.slice(5)),
   ],
-}));
-
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+});
 
 describe('round 5', () => {
   describe('Bypass Definition of Done', () => {
     it('This might seem like a good idea but always comes back to cause harm later', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 5);
       game.selectAction('BYPASS_DEFINITION_OF_DONE');
 
@@ -40,7 +34,7 @@ describe('round 5', () => {
   });
   describe('Include Stakeholders in updating Vision', () => {
     it('Time consuming but improves the likelihood that we will build the right product', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 5);
       game.selectAction('INCLUDE_STAKEHOLDERS_IN_VISION_UPDATE');
       testCurrentRound(game, { capacityChange: 0, userStoryChange: 0 });
@@ -56,7 +50,7 @@ describe('round 5', () => {
   });
   describe('Adopting BDD', () => {
     it('increases productivity by increasing collaboration between ppl on the team, improves likelihood of completing a User Story', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 5);
       expect(game.state.currentRound.number).toEqual(5);
 
@@ -75,7 +69,7 @@ describe('round 5', () => {
   });
   describe('Limit Product Backlog size', () => {
     it('By Limiting Product Backlog Size the PO avoids making unrealistic promise', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 5);
       expect(game.state.currentRound.number).toEqual(5);
 
@@ -94,7 +88,7 @@ describe('round 5', () => {
   });
   describe('Establish Sprint Goals', () => {
     it('is only available if refactoring was Backlog Refinement was implemented', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
 
       advanceGameToRound(game, 5);
       expect(game.state.currentRound.number).toEqual(5);
@@ -106,7 +100,7 @@ describe('round 5', () => {
       expect(game.availableActionIds).toContain('ESTABLISH_SPRINT_GOALS');
     });
     it('By Establishing Sprint Goals', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 4);
       game.selectAction('BACKLOG_REFINEMENT');
       game.nextRound();
@@ -115,22 +109,22 @@ describe('round 5', () => {
       game.selectAction('ESTABLISH_SPRINT_GOALS');
       testCurrentRound(game, {
         capacityChange: 0,
-        userStoryChange: 5 + BR_USER_STORY_CHANGE,
+        userStoryChange: 5,
       });
 
       testFutureRounds(game, [
-        { capacityChange: 0, userStoryChange: 5 + BR_USER_STORY_CHANGE },
-        { capacityChange: 0, userStoryChange: 10 + BR_USER_STORY_CHANGE },
-        { capacityChange: 0, userStoryChange: 10 + BR_USER_STORY_CHANGE },
-        { capacityChange: 0, userStoryChange: 15 + BR_USER_STORY_CHANGE },
-        { capacityChange: 0, userStoryChange: 15 + BR_USER_STORY_CHANGE },
-        { capacityChange: 0, userStoryChange: 15 + BR_USER_STORY_CHANGE },
+        { capacityChange: 0, userStoryChange: 5 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 10 },
+        { capacityChange: 0, userStoryChange: 15 },
+        { capacityChange: 0, userStoryChange: 15 },
+        { capacityChange: 0, userStoryChange: 15 },
       ]);
     });
   });
   describe('Post a public impediments list', () => {
     it('By making the teams impediments public', () => {
-      const game = getGame();
+      const game = getGame(testConfig);
       advanceGameToRound(game, 5);
       expect(game.state.currentRound.number).toEqual(5);
 

--- a/src/config/rounds/round5.tsx
+++ b/src/config/rounds/round5.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
-export const round5: RoundDescription = {
+export type Round5ActionId =
+  | 'BYPASS_DEFINITION_OF_DONE'
+  | 'INCLUDE_STAKEHOLDERS_IN_VISION_UPDATE'
+  | 'ADOPT_BDD'
+  | 'WORK_WITH_PO_LIMIT_PB_SIZE'
+  | 'ESTABLISH_SPRINT_GOALS'
+  | 'MAKE_IMPEDIMENTS_LIST_PUBLIC';
+
+export const round5: RoundDescription<Round5ActionId, GameActionId> = {
   title: 'Nearly There',
   description: (
     <p>

--- a/src/config/rounds/round5.tsx
+++ b/src/config/rounds/round5.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round5ActionId =
@@ -11,7 +10,7 @@ export type Round5ActionId =
   | 'ESTABLISH_SPRINT_GOALS'
   | 'MAKE_IMPEDIMENTS_LIST_PUBLIC';
 
-export const round5: RoundDescription<Round5ActionId, GameActionId> = {
+export const round5: RoundDescription<Round5ActionId> = {
   title: 'Nearly There',
   description: (
     <p>

--- a/src/config/rounds/round6.spec.tsx
+++ b/src/config/rounds/round6.spec.tsx
@@ -1,30 +1,25 @@
+import { rounds } from './index';
 import {
   advanceGameToRound,
   getGame,
   testCurrentRound,
   testFutureRounds,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 import { overtimeCapacityBump, overtimeUserStoryChance } from './round6';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
+const testConfig = config({
   rounds: [
-    require('./round1').round1,
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('./round6').round6,
+    ...defuseRounds(rounds.slice(0, 5)),
+    rounds[5],
+    ...defuseRounds(rounds.slice(6)),
   ],
-}));
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
+});
 
 describe('round 6', () => {
   it('comes with a 4 capacity bump', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
 
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
@@ -42,7 +37,7 @@ describe('round 6', () => {
 });
 describe('Improve Forecasting', () => {
   it("Doesn't have an immediate effect instead it protects against later gremlins since you can help people make better product decisions", () => {
-    const game = getGame();
+    const game = getGame(testConfig);
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
 
@@ -63,7 +58,7 @@ describe('Improve Forecasting', () => {
 });
 describe('Teams that take ownership of their Sprint Backlog', () => {
   it('Will make better use of the board improving both productivity and completion percentage by a bit', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
 
@@ -85,7 +80,7 @@ describe('Teams that take ownership of their Sprint Backlog', () => {
 });
 describe('Daily Scrum', () => {
   it('When daily Scrum is more effective problems get solved sooner and the team collaborates more', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
 
@@ -107,7 +102,7 @@ describe('Daily Scrum', () => {
 });
 describe('Improve Retrospectives', () => {
   it('Teams that make their retrospective action items concrete succeed in making more of their improvements', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
 
@@ -129,7 +124,7 @@ describe('Improve Retrospectives', () => {
 });
 describe('Learing Time', () => {
   it('Teams that take a limited amount of time to learn every Sprint grow', () => {
-    const game = getGame();
+    const game = getGame(testConfig);
     advanceGameToRound(game, 6);
     expect(game.state.currentRound.number).toEqual(6);
 

--- a/src/config/rounds/round6.tsx
+++ b/src/config/rounds/round6.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round6ActionId =
@@ -13,7 +12,7 @@ export type Round6ActionId =
 export const overtimeUserStoryChance = -20;
 export const overtimeCapacityBump = 4;
 
-export const round6: RoundDescription<Round6ActionId, GameActionId> = {
+export const round6: RoundDescription<Round6ActionId> = {
   title: 'Go Live Soon',
   description: (
     <p>

--- a/src/config/rounds/round6.tsx
+++ b/src/config/rounds/round6.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
+
+export type Round6ActionId =
+  | 'IMPROVE_FORECASTING'
+  | 'IMPROVE_RETROSPECTIVES_CONCRETE_ACTIONS'
+  | 'LEARNING_TIME'
+  | 'SPRINT_BACKLOG_IMPROVEMENT'
+  | 'DAILY_SCRUM_MORE_EFFECTIVE';
 
 export const overtimeUserStoryChance = -20;
 export const overtimeCapacityBump = 4;
 
-export const round6: RoundDescription = {
+export const round6: RoundDescription<Round6ActionId, GameActionId> = {
   title: 'Go Live Soon',
   description: (
     <p>

--- a/src/config/rounds/round7.spec.tsx
+++ b/src/config/rounds/round7.spec.tsx
@@ -1,67 +1,62 @@
+import { rounds } from './index';
 import {
   advanceGameToRound,
   getGame,
   testCurrentRound,
   testFutureRounds,
+  config,
+  defuseRounds,
 } from '../../lib/testHelpers';
 
-/* disable irrelevant other rounds */
-jest.mock('./index', () => ({
+const testConfig = config({
   rounds: [
-    require('./round1').round1,
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('../../lib/testHelpers').emptyRound(),
-    require('./round7').round7,
+    ...defuseRounds(rounds.slice(0, 6)),
+    rounds[6],
+    ...defuseRounds(rounds.slice(7)),
   ],
-}));
-/* disable game effect to only tests single actions */
-jest.mock('../gameEffects', () => ({
-  gameEffects: [],
-}));
-
-describe('round 7', () => {});
-describe('Pre-Allocate Capacity for fires', () => {
-  it('By setting aside some of the teams capacity for dealing with Production support -- no immediate effect', () => {
-    const game = getGame();
-    advanceGameToRound(game, 7);
-    expect(game.state.currentRound.number).toEqual(7);
-
-    game.selectAction('PREALLOCATE_CAPACITY_FOR_PRODUCTION_SUPPORT');
-    // round capacity bump still in effect
-    testCurrentRound(game, {
-      capacityChange: 0,
-      userStoryChange: 0,
-    });
-
-    testFutureRounds(game, [
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-    ]);
-  });
 });
-describe('Sacrifice One Team Member for fires', () => {
-  it('By finding one team member who is willing to be point person for a defect the rest of the team is able to focus', () => {
-    const game = getGame();
-    advanceGameToRound(game, 7);
-    expect(game.state.currentRound.number).toEqual(7);
 
-    game.selectAction('ONE_PERSON_DEALS_WITH_DEFECTS');
-    // round capacity bump still in effect
-    testCurrentRound(game, {
-      capacityChange: 0,
-      userStoryChange: 0,
+describe('round 7', () => {
+  describe('Pre-Allocate Capacity for fires', () => {
+    it('By setting aside some of the teams capacity for dealing with Production support -- no immediate effect', () => {
+      const game = getGame(testConfig);
+      advanceGameToRound(game, 7);
+      expect(game.state.currentRound.number).toEqual(7);
+
+      game.selectAction('PREALLOCATE_CAPACITY_FOR_PRODUCTION_SUPPORT');
+      // round capacity bump still in effect
+      testCurrentRound(game, {
+        capacityChange: 0,
+        userStoryChange: 0,
+      });
+
+      testFutureRounds(game, [
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+      ]);
     });
+  });
+  describe('Sacrifice One Team Member for fires', () => {
+    it('By finding one team member who is willing to be point person for a defect the rest of the team is able to focus', () => {
+      const game = getGame(testConfig);
+      advanceGameToRound(game, 7);
+      expect(game.state.currentRound.number).toEqual(7);
 
-    testFutureRounds(game, [
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-      { capacityChange: 0, userStoryChange: 0 },
-    ]);
+      game.selectAction('ONE_PERSON_DEALS_WITH_DEFECTS');
+      // round capacity bump still in effect
+      testCurrentRound(game, {
+        capacityChange: 0,
+        userStoryChange: 0,
+      });
+
+      testFutureRounds(game, [
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+        { capacityChange: 0, userStoryChange: 0 },
+      ]);
+    });
   });
 });

--- a/src/config/rounds/round7.tsx
+++ b/src/config/rounds/round7.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 import example from './images/example.jpg';
 
 export type Round7ActionId =
   | 'PREALLOCATE_CAPACITY_FOR_PRODUCTION_SUPPORT'
   | 'ONE_PERSON_DEALS_WITH_DEFECTS';
 
-export const round7: RoundDescription<Round7ActionId, GameActionId> = {
+export const round7: RoundDescription<Round7ActionId> = {
   title: "We're Live and We Have Real Customers",
   description: (
     <p>

--- a/src/config/rounds/round7.tsx
+++ b/src/config/rounds/round7.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 import example from './images/example.jpg';
 
-export const round7: RoundDescription = {
+export type Round7ActionId =
+  | 'PREALLOCATE_CAPACITY_FOR_PRODUCTION_SUPPORT'
+  | 'ONE_PERSON_DEALS_WITH_DEFECTS';
+
+export const round7: RoundDescription<Round7ActionId, GameActionId> = {
   title: "We're Live and We Have Real Customers",
   description: (
     <p>

--- a/src/config/rounds/round8.tsx
+++ b/src/config/rounds/round8.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import type { GameActionId } from './index';
-import type { RoundDescription } from '../../state';
+import type { RoundDescription } from './index';
 
-export const round8: RoundDescription<never, GameActionId> = {
+export const round8: RoundDescription<never> = {
   title: 'TODO: ADD TITLE',
   description: <p>{/* TODO: ADD DESCRIPTION */}</p>,
   actions: {},

--- a/src/config/rounds/round8.tsx
+++ b/src/config/rounds/round8.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import type { GameActionId } from './index';
 import type { RoundDescription } from '../../state';
 
-export const round8: RoundDescription = {
+export const round8: RoundDescription<never, GameActionId> = {
   title: 'TODO: ADD TITLE',
   description: <p>{/* TODO: ADD DESCRIPTION */}</p>,
   actions: {},

--- a/src/lib/findGameActionById.ts
+++ b/src/lib/findGameActionById.ts
@@ -1,9 +1,12 @@
 import { getAllGameActions } from './getAllGameActions';
 import type { GameAction, GameConfig } from '../state/game';
 
-export function findGameActionById<GameActionId extends string>(
+export function findGameActionById<
+  GameActionId extends string,
+  GremlinId extends string
+>(
   gameActionId: GameActionId,
-  rounds: GameConfig<GameActionId>['rounds'],
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ): GameAction<GameActionId> {
   const gameActions = getAllGameActions(rounds);
 

--- a/src/lib/findGameActionById.ts
+++ b/src/lib/findGameActionById.ts
@@ -1,10 +1,10 @@
 import { getAllGameActions } from './getAllGameActions';
 import type { GameAction, GameConfig } from '../state/game';
 
-export function findGameActionById(
-  gameActionId: string,
-  rounds: GameConfig['rounds'],
-): GameAction {
+export function findGameActionById<GameActionId extends string>(
+  gameActionId: GameActionId,
+  rounds: GameConfig<GameActionId>['rounds'],
+): GameAction<GameActionId> {
   const gameActions = getAllGameActions(rounds);
 
   const gameAction = gameActions.find(

--- a/src/lib/getAllGameActions.ts
+++ b/src/lib/getAllGameActions.ts
@@ -2,13 +2,15 @@ import memoizeOne from 'memoize-one';
 import { GameConfig, GameAction } from '../state/game';
 
 export const getAllGameActions = memoizeOne(
-  (rounds: GameConfig['rounds']): GameAction[] => {
+  <GameActionId extends string>(
+    rounds: GameConfig<GameActionId>['rounds'],
+  ): GameAction<GameActionId>[] => {
     return rounds
       .map((round, i) => {
         return Object.entries(round.actions).map(([actionId, action]) => ({
           ...action,
           round: i + 1,
-          id: actionId,
+          id: actionId as GameActionId,
         }));
       })
       .flat();

--- a/src/lib/getAllGameActions.ts
+++ b/src/lib/getAllGameActions.ts
@@ -2,8 +2,8 @@ import memoizeOne from 'memoize-one';
 import { GameConfig, GameAction } from '../state/game';
 
 export const getAllGameActions = memoizeOne(
-  <GameActionId extends string>(
-    rounds: GameConfig<GameActionId>['rounds'],
+  <GameActionId extends string, GremlinId extends string>(
+    rounds: GameConfig<GameActionId, GremlinId>['rounds'],
   ): GameAction<GameActionId>[] => {
     return rounds
       .map((round, i) => {

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -1,14 +1,18 @@
 import type { GameState } from '../state';
 
-export const INITIAL_STATE: GameState = {
-  currentRound: {
-    gremlin: null,
-    selectedGameActionIds: [],
-  },
-  pastRounds: [],
-  ui: {
-    review: false,
-    view: 'welcome',
-  },
-  log: [],
-};
+export function createInitialState<GameActionId extends string>(): GameState<
+  GameActionId
+> {
+  return {
+    currentRound: {
+      gremlin: null,
+      selectedGameActionIds: [],
+    },
+    pastRounds: [],
+    ui: {
+      review: false,
+      view: 'welcome',
+    },
+    log: [],
+  };
+}

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -1,8 +1,9 @@
 import type { GameState } from '../state';
 
-export function createInitialState<GameActionId extends string>(): GameState<
-  GameActionId
-> {
+export function createInitialState<
+  GameActionId extends string,
+  GremlinId extends string
+>(): GameState<GameActionId, GremlinId> {
   return {
     currentRound: {
       gremlin: null,

--- a/src/lib/isGameActionWithImage.ts
+++ b/src/lib/isGameActionWithImage.ts
@@ -1,7 +1,7 @@
 import type { GameAction, GameActionWithImage } from '../state';
 
-export function isGameActionWithImage(
-  action: GameAction,
-): action is GameActionWithImage {
+export function isGameActionWithImage<GameActionId extends string>(
+  action: GameAction<GameActionId>,
+): action is GameActionWithImage<GameActionId> {
   return Object.getOwnPropertyNames(action).includes('image');
 }

--- a/src/lib/persistState.ts
+++ b/src/lib/persistState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { GameState } from '../state/game';
-import { INITIAL_STATE } from './initialState';
+import { createInitialState } from './initialState';
 import versionP from './version';
 
 const LOCAL_STATE_KEY = 'TEAM_GAME_STATE';
@@ -45,7 +45,7 @@ export async function getInitialState(): Promise<InitialStateWithStatus> {
   }
 
   if (localStateData === null) {
-    return { state: INITIAL_STATE, status: GAME_STATE_OK };
+    return { state: createInitialState(), status: GAME_STATE_OK };
   }
 
   try {
@@ -58,7 +58,7 @@ export async function getInitialState(): Promise<InitialStateWithStatus> {
     };
   } catch (err) {
     console.warn(err);
-    return { state: INITIAL_STATE, status: GAME_STATE_OK };
+    return { state: createInitialState(), status: GAME_STATE_OK };
   }
 }
 

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -1,21 +1,75 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useAppState } from './useAppState';
 import { createInitialState } from './initialState';
-import { BaseEffect, RoundDescription } from '../state';
-import { config, GameActionId, GremlinId } from '../config';
+import { AppState, BaseEffect, GameConfig, RoundDescription } from '../state';
+import { ClosedGameRound } from '../state/round';
+import { Icon, GameActionImplementation } from '../state/gameActions/types';
 
-export function emptyRound(): RoundDescription<never, any, any> {
+export function config<A extends string, G extends string>(
+  opts: Partial<GameConfig<A, G>> = {},
+  interactiveRounds: number = 0,
+): GameConfig<A, G> {
+  const rounds = opts.rounds || [];
+  while (rounds.length < interactiveRounds) {
+    rounds.push(round());
+  }
   return {
-    title: 'EmptyRound',
-    description: null,
-    actions: {},
+    trailingRounds: opts.trailingRounds || 0,
+    initialScores: {
+      userStoryChange: 7,
+      capacityChange: 7,
+      ...opts.initialScores,
+    },
+    rounds,
+    gremlins: {
+      ...(opts.gremlins as any),
+    },
+    gameEffects: {
+      ...opts.gameEffects,
+    },
   };
 }
 
-export function getGame() {
+export function round<K extends string>(
+  opts: Partial<RoundDescription<K, any, any>> = {},
+) {
+  return {
+    title: 'EmptyRound',
+    description: null,
+    ...opts,
+    actions: {
+      ...opts.actions,
+    },
+  };
+}
+
+export function action<A extends string>(
+  opts: Partial<GameActionImplementation<A>> = {},
+): GameActionImplementation<A> & Icon {
+  return {
+    icon: '🤷',
+    name: 'Some Action',
+    cost: 0,
+    description: null,
+    ...opts,
+  };
+}
+
+type GameHelper<GameActionId extends string, GremlinId extends string> = {
+  config: GameConfig<GameActionId, GremlinId>;
+  readonly state: AppState<GameActionId, GremlinId>;
+  readonly availableActionIds: GameActionId[];
+  closeRound: () => ClosedGameRound<GameActionId, GremlinId>;
+  nextRound: (GremlinId?: GremlinId | null) => void;
+  selectAction: (gameActionId: GameActionId) => void;
+};
+export function getGame<GameActionId extends string, GremlinId extends string>(
+  config: GameConfig<GameActionId, GremlinId>,
+): GameHelper<GameActionId, GremlinId> {
   const wrapper = renderHook(() => useAppState(config, createInitialState()));
 
   return {
+    config,
     get state() {
       return wrapper.result.current[0];
     },
@@ -52,26 +106,43 @@ export function getGame() {
   };
 }
 
-export function advanceGameToRound(
-  game: ReturnType<typeof getGame>,
-  desiredRound: number,
-) {
+export function defuseRounds<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  rounds: RoundDescription<string, GameActionId, GremlinId>[],
+): RoundDescription<string, GameActionId, GremlinId>[] {
+  return rounds.map((roundDescription) =>
+    round({
+      actions: Object.fromEntries(
+        Object.keys(roundDescription.actions).map((id) => {
+          return [id, action()];
+        }),
+      ),
+    }),
+  );
+}
+
+export function advanceGameToRound<
+  GameActionId extends string,
+  GremlinId extends string
+>(game: GameHelper<GameActionId, GremlinId>, desiredRound: number) {
   while (game.state.currentRound.number < desiredRound) {
     game.nextRound();
   }
 }
-export function testCurrentRound(
-  game: ReturnType<typeof getGame>,
-  round: BaseEffect,
-) {
+export function testCurrentRound<
+  GameActionId extends string,
+  GremlinId extends string
+>(game: GameHelper<GameActionId, GremlinId>, round: BaseEffect) {
   if (round.userStoryChange !== undefined) {
     expect(game.state.currentRound).toHaveUserStoryChance(
-      round.userStoryChange + (config.initialScores.userStoryChange || 0),
+      round.userStoryChange + (game.config.initialScores.userStoryChange || 0),
     );
   }
   if (round.capacityChange !== undefined) {
     expect(game.state.currentRound).toHaveTotalCapacity(
-      round.capacityChange + (config.initialScores.capacityChange || 0),
+      round.capacityChange + (game.config.initialScores.capacityChange || 0),
     );
   }
   if (round.gremlinChange !== undefined) {
@@ -79,10 +150,10 @@ export function testCurrentRound(
   }
 }
 
-export function testFutureRounds(
-  game: ReturnType<typeof getGame>,
-  futureRounds: BaseEffect[],
-) {
+export function testFutureRounds<
+  GameActionId extends string,
+  GremlinId extends string
+>(game: GameHelper<GameActionId, GremlinId>, futureRounds: BaseEffect[]) {
   futureRounds.forEach((round) => {
     game.nextRound();
     testCurrentRound(game, round);

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -66,12 +66,12 @@ export function testCurrentRound(
 ) {
   if (round.userStoryChange !== undefined) {
     expect(game.state.currentRound).toHaveUserStoryChance(
-      round.userStoryChange + 30,
+      round.userStoryChange + (config.initialScores.userStoryChange || 0),
     );
   }
   if (round.capacityChange !== undefined) {
     expect(game.state.currentRound).toHaveTotalCapacity(
-      round.capacityChange + 10,
+      round.capacityChange + (config.initialScores.capacityChange || 0),
     );
   }
   if (round.gremlinChange !== undefined) {

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -2,9 +2,9 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { useAppState } from './useAppState';
 import { createInitialState } from './initialState';
 import { BaseEffect, RoundDescription } from '../state';
-import { config, GameActionId } from '../config';
+import { config, GameActionId, GremlinId } from '../config';
 
-export function emptyRound(): RoundDescription<never, any> {
+export function emptyRound(): RoundDescription<never, any, any> {
   return {
     title: 'EmptyRound',
     description: null,
@@ -29,7 +29,7 @@ export function getGame() {
     closeRound: () => {
       return wrapper.result.current[1]();
     },
-    nextRound: (gremlin: string | null = null) => {
+    nextRound: (gremlin: GremlinId | null = null) => {
       const closedRound = {
         ...wrapper.result.current[1](),
       };

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -1,10 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useAppState } from './useAppState';
-import { INITIAL_STATE } from './initialState';
+import { createInitialState } from './initialState';
 import { BaseEffect, RoundDescription } from '../state';
-import { config } from '../config';
+import { config, GameActionId } from '../config';
 
-export function emptyRound(): RoundDescription {
+export function emptyRound(): RoundDescription<never, any> {
   return {
     title: 'EmptyRound',
     description: null,
@@ -13,7 +13,7 @@ export function emptyRound(): RoundDescription {
 }
 
 export function getGame() {
-  const wrapper = renderHook(() => useAppState(INITIAL_STATE, config));
+  const wrapper = renderHook(() => useAppState(config, createInitialState()));
 
   return {
     get state() {
@@ -41,7 +41,7 @@ export function getGame() {
         });
       });
     },
-    selectAction: (gameActionId: string) => {
+    selectAction: (gameActionId: GameActionId) => {
       act(() => {
         wrapper.result.current[4]({
           type: 'SELECT_GAME_ACTION',

--- a/src/lib/useAppState.ts
+++ b/src/lib/useAppState.ts
@@ -22,7 +22,7 @@ export function useAppState<
   config: GameConfig<GameActionId, GremlinId>,
   initialState: GameState<GameActionId, GremlinId>,
 ): [
-  AppState<GameActionId>,
+  AppState<GameActionId, GremlinId>,
   () => ClosedRound<GameActionId, GremlinId>,
   () => GremlinId | null,
   string,

--- a/src/lib/useAppState.ts
+++ b/src/lib/useAppState.ts
@@ -8,19 +8,31 @@ import type {
 } from '../state';
 import { createGameReducer, deriveAppState } from '../state';
 import { usePersistState, useStateLink } from '../lib';
+import { createInitialState } from './initialState';
 
-export type GameDispatch = Dispatch<Action>;
+export type GameDispatch<GameActionId extends string = string> = Dispatch<
+  Action<GameActionId>
+>;
 
-export function useAppState(
-  initialState: GameState,
-  config: GameConfig,
-): [AppState, () => ClosedRound, () => string | null, string, GameDispatch] {
-  const gameReducer = useMemo(() => createGameReducer(config), [config]);
+export function useAppState<GameActionId extends string>(
+  config: GameConfig<GameActionId>,
+  initialState: GameState<GameActionId>,
+): [
+  AppState<GameActionId>,
+  () => ClosedRound<GameActionId>,
+  () => string | null,
+  string,
+  GameDispatch<GameActionId>,
+] {
+  const gameReducer = useMemo(
+    () => createGameReducer(config, createInitialState()),
+    [config],
+  );
   const [gameState, dispatch] = useReducer(gameReducer, initialState);
   usePersistState(gameState);
   const link = useStateLink(gameState);
 
-  const state: GameState =
+  const state: GameState<GameActionId> =
     gameState.ui.review === false
       ? gameState
       : {

--- a/src/lib/useAppState.ts
+++ b/src/lib/useAppState.ts
@@ -10,19 +10,23 @@ import { createGameReducer, deriveAppState } from '../state';
 import { usePersistState, useStateLink } from '../lib';
 import { createInitialState } from './initialState';
 
-export type GameDispatch<GameActionId extends string = string> = Dispatch<
-  Action<GameActionId>
->;
+export type GameDispatch<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+> = Dispatch<Action<GameActionId, GremlinId>>;
 
-export function useAppState<GameActionId extends string>(
-  config: GameConfig<GameActionId>,
-  initialState: GameState<GameActionId>,
+export function useAppState<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  config: GameConfig<GameActionId, GremlinId>,
+  initialState: GameState<GameActionId, GremlinId>,
 ): [
   AppState<GameActionId>,
-  () => ClosedRound<GameActionId>,
-  () => string | null,
+  () => ClosedRound<GameActionId, GremlinId>,
+  () => GremlinId | null,
   string,
-  GameDispatch<GameActionId>,
+  GameDispatch<GameActionId, GremlinId>,
 ] {
   const gameReducer = useMemo(
     () => createGameReducer(config, createInitialState()),
@@ -32,7 +36,7 @@ export function useAppState<GameActionId extends string>(
   usePersistState(gameState);
   const link = useStateLink(gameState);
 
-  const state: GameState<GameActionId> =
+  const state: GameState<GameActionId, GremlinId> =
     gameState.ui.review === false
       ? gameState
       : {

--- a/src/state/deriveAppState.ts
+++ b/src/state/deriveAppState.ts
@@ -9,21 +9,27 @@ type PastRound<GameActionId extends string> = AppRound<GameActionId> & {
   storiesCompleted: number;
 };
 
-export type AppState<GameActionId extends string = string> = {
+export type AppState<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+> = {
   availableGameActions: GameActionWithStatus<GameActionId>[];
   currentRound: AppRound<GameActionId>;
   pastRounds: PastRound<GameActionId>[];
-  ui: GameState<GameActionId>['ui'];
-  log: GameState<GameActionId>['log'];
+  ui: GameState<GameActionId, GremlinId>['ui'];
+  log: GameState<GameActionId, GremlinId>['log'];
 };
 
-export function deriveAppState<GameActionId extends string>(
-  state: GameState<GameActionId>,
-  config: GameConfig<GameActionId>,
+export function deriveAppState<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: GameState<GameActionId, GremlinId>,
+  config: GameConfig<GameActionId, GremlinId>,
 ): [
-  AppState<GameActionId>,
-  () => ClosedGameRound<GameActionId>,
-  () => string | null,
+  AppState<GameActionId, GremlinId>,
+  () => ClosedGameRound<GameActionId, GremlinId>,
+  () => GremlinId | null,
 ] {
   const availableGameActions = getAvailableGameActions(
     state.pastRounds.length,

--- a/src/state/deriveAppState.ts
+++ b/src/state/deriveAppState.ts
@@ -5,22 +5,26 @@ import { GameActionWithStatus } from './gameActions/getAvailableGameActions';
 import { rollGremlin } from './gremlins';
 import { AppRound, ClosedGameRound, closeRound, deriveAppRound } from './round';
 
-type PastRound = AppRound & {
+type PastRound<GameActionId extends string> = AppRound<GameActionId> & {
   storiesCompleted: number;
 };
 
-export type AppState = {
-  availableGameActions: GameActionWithStatus[];
-  currentRound: AppRound;
-  pastRounds: PastRound[];
-  ui: GameState['ui'];
-  log: GameState['log'];
+export type AppState<GameActionId extends string = string> = {
+  availableGameActions: GameActionWithStatus<GameActionId>[];
+  currentRound: AppRound<GameActionId>;
+  pastRounds: PastRound<GameActionId>[];
+  ui: GameState<GameActionId>['ui'];
+  log: GameState<GameActionId>['log'];
 };
 
-export function deriveAppState(
-  state: GameState,
-  config: GameConfig,
-): [AppState, () => ClosedGameRound, () => string | null] {
+export function deriveAppState<GameActionId extends string>(
+  state: GameState<GameActionId>,
+  config: GameConfig<GameActionId>,
+): [
+  AppState<GameActionId>,
+  () => ClosedGameRound<GameActionId>,
+  () => string | null,
+] {
   const availableGameActions = getAvailableGameActions(
     state.pastRounds.length,
     concatByProp(state.pastRounds, 'selectedGameActionIds'),

--- a/src/state/effects/types.ts
+++ b/src/state/effects/types.ts
@@ -23,4 +23,6 @@ export type BaseEffect = {
 export type InvisibleEffect = BaseEffect & InvisibleEffectProps;
 export type VisibleEffect = BaseEffect & VisibleEffectProps;
 export type Effect = BaseEffect & EffectDescription;
-export type GameEffect = (rounds: GameRound[]) => Effect[] | Effect | null;
+export type GameEffect<GameActionId extends string> = (
+  rounds: GameRound<GameActionId>[],
+) => Effect[] | Effect | null;

--- a/src/state/effects/types.ts
+++ b/src/state/effects/types.ts
@@ -23,6 +23,7 @@ export type BaseEffect = {
 export type InvisibleEffect = BaseEffect & InvisibleEffectProps;
 export type VisibleEffect = BaseEffect & VisibleEffectProps;
 export type Effect = BaseEffect & EffectDescription;
-export type GameEffect<GameActionId extends string> = (
-  rounds: GameRound<GameActionId>[],
-) => Effect[] | Effect | null;
+export type GameEffect<
+  GameActionId extends string,
+  GremlinId extends string
+> = (rounds: GameRound<GameActionId, GremlinId>[]) => Effect[] | Effect | null;

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -13,15 +13,18 @@ import { getGremlinEffects, GremlinList } from './gremlins';
 import { RoundDescription } from './rounds/types';
 export type { GameAction } from './gameActions';
 
-export type GameState<GameActionId extends string = string> = {
-  currentRound: GameRound<GameActionId>;
-  pastRounds: ClosedGameRound<GameActionId>[];
+export type GameState<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+> = {
+  currentRound: GameRound<GameActionId, GremlinId>;
+  pastRounds: ClosedGameRound<GameActionId, GremlinId>[];
   ui: {
     review: false | number;
     view: 'welcome' | 'actions' | 'results';
-    closedRound?: ClosedGameRound<GameActionId>;
+    closedRound?: ClosedGameRound<GameActionId, GremlinId>;
   };
-  log: RunningGameAction<GameActionId>[];
+  log: RunningGameAction<GameActionId, GremlinId>[];
 };
 
 export type RestartGameAction = {
@@ -35,9 +38,12 @@ export type SetUiViewAction = {
   type: 'SET_UI_VIEW_ACTION';
   payload: GameState['ui']['view'];
 };
-export type SetUiClosedRoundAction<GameActionId extends string> = {
+export type SetUiClosedRoundAction<
+  GameActionId extends string,
+  GremlinId extends string
+> = {
   type: 'SET_UI_CLOSED_ROUND_ACTION';
-  payload: ClosedGameRound<GameActionId>;
+  payload: ClosedGameRound<GameActionId, GremlinId>;
 };
 export type SelectGameActionAction<GameActionId extends string> = {
   type: 'SELECT_GAME_ACTION';
@@ -47,46 +53,61 @@ export type UnselectGameActionAction<GameActionId extends string> = {
   type: 'UNSELECT_GAME_ACTION';
   payload: GameActionId;
 };
-export type NextRoundAction<GameActionId extends string> = {
+export type NextRoundAction<
+  GameActionId extends string,
+  GremlinId extends string
+> = {
   type: 'NEXT_ROUND';
   payload: {
-    closedRound: ClosedGameRound<GameActionId>;
-    gremlin: string | null;
+    closedRound: ClosedGameRound<GameActionId, GremlinId>;
+    gremlin: GremlinId | null;
   };
 };
-export type FinishGameAction<GameActionId extends string> = {
+export type FinishGameAction<
+  GameActionId extends string,
+  GremlinId extends string
+> = {
   type: 'FINISH_GAME';
   payload: {
-    closedRound: ClosedGameRound<GameActionId>;
+    closedRound: ClosedGameRound<GameActionId, GremlinId>;
   };
 };
 export type GameActionAction<GameActionId extends string = string> =
   | SelectGameActionAction<GameActionId>
   | UnselectGameActionAction<GameActionId>;
-type RunningGameAction<GameActionId extends string> =
+type RunningGameAction<GameActionId extends string, GremlinId extends string> =
   | GameActionAction<GameActionId>
-  | NextRoundAction<GameActionId>;
-type UiAction<GameActionId extends string> =
+  | NextRoundAction<GameActionId, GremlinId>;
+type UiAction<GameActionId extends string, GremlinId extends string> =
   | SetUiViewAction
-  | SetUiClosedRoundAction<GameActionId>
+  | SetUiClosedRoundAction<GameActionId, GremlinId>
   | SetUiReviewAction;
 
-export type Action<GameActionId extends string> =
-  | RunningGameAction<GameActionId>
+export type Action<GameActionId extends string, GremlinId extends string> =
+  | RunningGameAction<GameActionId, GremlinId>
   | RestartGameAction
-  | FinishGameAction<GameActionId>
-  | UiAction<GameActionId>;
+  | FinishGameAction<GameActionId, GremlinId>
+  | UiAction<GameActionId, GremlinId>;
 
-export type GameConfig<GameActionId extends string = string> = {
+export type GameConfig<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+> = {
   trailingRounds: number;
-  rounds: RoundDescription<string, GameActionId>[];
-  gremlins: GremlinList<GameActionId>;
-  gameEffects: { [key: string]: GameEffect<GameActionId> };
+  rounds: RoundDescription<string, GameActionId, GremlinId>[];
+  gremlins: GremlinList<GremlinId, GameActionId>;
+  gameEffects: { [key: string]: GameEffect<GameActionId, GremlinId> };
 };
 
-export function getAllEffects<GameActionId extends string>(
-  state: Pick<GameState<GameActionId>, 'currentRound' | 'pastRounds'>,
-  config: GameConfig<GameActionId>,
+export function getAllEffects<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: Pick<
+    GameState<GameActionId, GremlinId>,
+    'currentRound' | 'pastRounds'
+  >,
+  config: GameConfig<GameActionId, GremlinId>,
   finishedActionIds: GameActionId[] = concatByProp(
     state.pastRounds,
     'selectedGameActionIds',
@@ -161,10 +182,10 @@ export function getCapacity(effects: Effect[]) {
   }, 0);
 }
 
-function nextRound<GameActionId extends string>(
-  state: GameState<GameActionId>,
-  action: NextRoundAction<GameActionId>,
-): GameState<GameActionId> {
+function nextRound<GameActionId extends string, GremlinId extends string>(
+  state: GameState<GameActionId, GremlinId>,
+  action: NextRoundAction<GameActionId, GremlinId>,
+): GameState<GameActionId, GremlinId> {
   return {
     ...state,
     ui: {
@@ -172,19 +193,22 @@ function nextRound<GameActionId extends string>(
       view: 'welcome',
     },
     pastRounds: [...state.pastRounds, action.payload.closedRound],
-    currentRound: createRound(action.payload.gremlin),
+    currentRound: createRound<GameActionId, GremlinId>(action.payload.gremlin),
     log: state.log.concat(action),
   };
 }
 
-export function createGameReducer<GameActionId extends string>(
-  config: GameConfig<GameActionId>,
-  initialState: GameState<GameActionId>,
+export function createGameReducer<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  config: GameConfig<GameActionId, GremlinId>,
+  initialState: GameState<GameActionId, GremlinId>,
 ) {
   return (
-    state: GameState<GameActionId>,
-    action: Action<GameActionId>,
-  ): GameState<GameActionId> => {
+    state: GameState<GameActionId, GremlinId>,
+    action: Action<GameActionId, GremlinId>,
+  ): GameState<GameActionId, GremlinId> => {
     switch (action.type) {
       case 'SELECT_GAME_ACTION': {
         return {
@@ -220,7 +244,12 @@ export function createGameReducer<GameActionId extends string>(
             config.rounds.length +
             config.trailingRounds -
             state.pastRounds.length,
-        }).reduce<[GameState<GameActionId>, ClosedGameRound<GameActionId>]>(
+        }).reduce<
+          [
+            GameState<GameActionId, GremlinId>,
+            ClosedGameRound<GameActionId, GremlinId>,
+          ]
+        >(
           ([state, closedRound]) => {
             const nextState = nextRound(state, {
               type: 'NEXT_ROUND',
@@ -230,7 +259,10 @@ export function createGameReducer<GameActionId extends string>(
               },
             });
 
-            return [nextState, closeRound<GameActionId>(nextState, config)];
+            return [
+              nextState,
+              closeRound<GameActionId, GremlinId>(nextState, config),
+            ];
           },
           [state, action.payload.closedRound],
         )[0];

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -6,7 +6,7 @@ import {
   closeRound,
   getActionEffects,
 } from './round';
-import { Effect, GameEffect, isEffect } from './effects';
+import { BaseEffect, Effect, GameEffect, isEffect } from './effects';
 import { getRoundEffects } from './rounds';
 import { getEffects } from './gameActions';
 import { getGremlinEffects, GremlinList } from './gremlins';
@@ -93,6 +93,7 @@ export type GameConfig<
   GameActionId extends string = string,
   GremlinId extends string = string
 > = {
+  initialScores: BaseEffect;
   trailingRounds: number;
   rounds: RoundDescription<string, GameActionId, GremlinId>[];
   gremlins: GremlinList<GremlinId, GameActionId>;
@@ -113,7 +114,7 @@ export function getAllEffects<
     'selectedGameActionIds',
   ),
 ) {
-  const effects: Effect[] = [];
+  const effects: Effect[] = [{ title: false, ...config.initialScores }];
 
   /* Base round effects of past rounds */
   effects.push(...getRoundEffects(state, config.rounds));

--- a/src/state/gameActions/getAvailableGameActions.ts
+++ b/src/state/gameActions/getAvailableGameActions.ts
@@ -33,11 +33,14 @@ export type GameActionWithStatus<GameActionId extends string = string> = {
   status: GameActionStatus<GameActionId>;
 };
 
-export function getAvailableGameActions<GameActionId extends string>(
+export function getAvailableGameActions<
+  GameActionId extends string,
+  GremlinId extends string
+>(
   currentRoundIndex: number,
   finishedActionIds: GameActionId[],
   selectedGameActionIds: GameActionId[],
-  rounds: GameConfig<GameActionId>['rounds'],
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ): GameActionWithStatus<GameActionId>[] {
   return getAllGameActions(rounds)
     .map((gameAction): GameActionWithStatus<GameActionId> | null => {

--- a/src/state/gameActions/getAvailableGameActions.ts
+++ b/src/state/gameActions/getAvailableGameActions.ts
@@ -6,8 +6,8 @@ import { GameConfig } from '../game';
 export const UNIQUE = Symbol('UNIQUE');
 
 type Times = typeof UNIQUE | number;
-type GameActionStatus = {
-  dependencies: (GameAction & { missing: boolean })[];
+type GameActionStatus<GameActionId extends string> = {
+  dependencies: (GameAction<GameActionId> & { missing: boolean })[];
 } & (
   | { type: 'MISSING_DEP' }
   | { type: 'AVAILABLE'; times: Times }
@@ -15,7 +15,9 @@ type GameActionStatus = {
   | { type: 'FINISHED' }
 );
 
-function getDependencies(gameAction: GameAction): string[] {
+function getDependencies<GameActionId extends string>(
+  gameAction: GameAction<GameActionId>,
+): GameActionId[] {
   const req = gameAction.available?.requires;
   if (!req) {
     return [];
@@ -26,19 +28,19 @@ function getDependencies(gameAction: GameAction): string[] {
   return req;
 }
 
-export type GameActionWithStatus = {
-  gameAction: GameAction;
-  status: GameActionStatus;
+export type GameActionWithStatus<GameActionId extends string = string> = {
+  gameAction: GameAction<GameActionId>;
+  status: GameActionStatus<GameActionId>;
 };
 
-export function getAvailableGameActions(
+export function getAvailableGameActions<GameActionId extends string>(
   currentRoundIndex: number,
-  finishedActionIds: string[],
-  selectedGameActionIds: string[],
-  rounds: GameConfig['rounds'],
-): GameActionWithStatus[] {
+  finishedActionIds: GameActionId[],
+  selectedGameActionIds: GameActionId[],
+  rounds: GameConfig<GameActionId>['rounds'],
+): GameActionWithStatus<GameActionId>[] {
   return getAllGameActions(rounds)
-    .map((gameAction): GameActionWithStatus | null => {
+    .map((gameAction): GameActionWithStatus<GameActionId> | null => {
       if (currentRoundIndex + 1 < gameAction.round) {
         return null;
       }
@@ -87,5 +89,5 @@ export function getAvailableGameActions(
           : { type: 'AVAILABLE', times, dependencies },
       };
     })
-    .filter((e): e is GameActionWithStatus => e !== null);
+    .filter((e): e is GameActionWithStatus<GameActionId> => e !== null);
 }

--- a/src/state/gameActions/getCost.ts
+++ b/src/state/gameActions/getCost.ts
@@ -1,5 +1,7 @@
 import { GameAction } from './types';
 
-export function getCost(gameAction: GameAction): number {
+export function getCost<GameActionId extends string>(
+  gameAction: GameAction<GameActionId>,
+): number {
   return gameAction.cost;
 }

--- a/src/state/gameActions/getEffects.ts
+++ b/src/state/gameActions/getEffects.ts
@@ -2,11 +2,11 @@ import { Effect } from '../effects';
 import { findGameActionById } from '../../lib/findGameActionById';
 import { GameConfig } from '../game';
 
-export function getEffects(
-  gameActionId: string,
+export function getEffects<GameActionId extends string>(
+  gameActionId: GameActionId,
   age: number,
-  finishedActionIds: string[],
-  rounds: GameConfig['rounds'],
+  finishedActionIds: GameActionId[],
+  rounds: GameConfig<GameActionId>['rounds'],
 ): Effect[] {
   const gameAction = findGameActionById(gameActionId, rounds);
   const effect = gameAction.effect?.(age, finishedActionIds) || null;

--- a/src/state/gameActions/getEffects.ts
+++ b/src/state/gameActions/getEffects.ts
@@ -2,11 +2,14 @@ import { Effect } from '../effects';
 import { findGameActionById } from '../../lib/findGameActionById';
 import { GameConfig } from '../game';
 
-export function getEffects<GameActionId extends string>(
+export function getEffects<
+  GameActionId extends string,
+  GremlinId extends string
+>(
   gameActionId: GameActionId,
   age: number,
   finishedActionIds: GameActionId[],
-  rounds: GameConfig<GameActionId>['rounds'],
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ): Effect[] {
   const gameAction = findGameActionById(gameActionId, rounds);
   const effect = gameAction.effect?.(age, finishedActionIds) || null;

--- a/src/state/gameActions/types.ts
+++ b/src/state/gameActions/types.ts
@@ -26,36 +26,41 @@ type Icon = {
    */
   icon: string;
 };
-// export function isGameActionWithIcon(
-//   action: GameAction,
-// ): action is FullGameAction & Icon {
-//   return Object.getOwnPropertyNames(action).includes('icon');
-// }
+
 type ImageOrIcon = Image | Icon;
 
-export type GameActionWithImage = FullGameAction & Image;
-export type GameActionWithIcon = FullGameAction & Icon;
+export type GameActionWithImage<GameActionId extends string> = FullGameAction<
+  GameActionId
+> &
+  Image;
+export type GameActionWithIcon<GameActionId extends string> = FullGameAction<
+  GameActionId
+> &
+  Icon;
 
-type GameActionImplementation = {
+type GameActionImplementation<GameActionId extends string> = {
   type?: string;
   available?: {
-    requires?: string[] | string;
+    requires?: GameActionId[] | GameActionId;
     unique?: false;
   };
   effect?: (
     age: number,
-    finishedActionIds: string[],
+    finishedActionIds: GameActionId[],
   ) => Effect[] | EffectWithOptionalTitle | null;
   name: string;
   description: ReactNode;
   cost: number;
 };
-type FullGameAction = GameActionImplementation & {
-  id: string;
+type FullGameAction<GameActionId extends string> = GameActionImplementation<
+  GameActionId
+> & {
+  id: GameActionId;
   round: number;
 };
-export type GameActionList = {
-  [key: string]: ImageOrIcon & GameActionImplementation;
+export type GameActionList<Key extends string, GameActionId extends string> = {
+  [K in Key]: ImageOrIcon & GameActionImplementation<GameActionId>;
 };
 
-export type GameAction = ImageOrIcon & FullGameAction;
+export type GameAction<GameActionId extends string = string> = ImageOrIcon &
+  FullGameAction<GameActionId>;

--- a/src/state/gameActions/types.ts
+++ b/src/state/gameActions/types.ts
@@ -19,7 +19,7 @@ type Image = {
   image: string;
 };
 
-type Icon = {
+export type Icon = {
   /**
    * Unicode Character to be displayed instead of image
    * can be emoji or any other char
@@ -38,7 +38,7 @@ export type GameActionWithIcon<GameActionId extends string> = FullGameAction<
 > &
   Icon;
 
-type GameActionImplementation<GameActionId extends string> = {
+export type GameActionImplementation<GameActionId extends string> = {
   type?: string;
   available?: {
     requires?: GameActionId[] | GameActionId;

--- a/src/state/gremlins.spec.ts
+++ b/src/state/gremlins.spec.ts
@@ -1,5 +1,5 @@
 import { createInitialState } from '../lib';
-import { emptyRound } from '../lib/testHelpers';
+import { round } from '../lib/testHelpers';
 import { rollGremlin } from './gremlins';
 import { reset, addRolls } from '../lib/notRandom';
 import type { GameConfig } from './game';
@@ -13,7 +13,7 @@ describe('rollGremlin', () => {
     reset();
     config = {
       initialScores: { gremlinChange: 50, userStoryChange: 30 },
-      rounds: [emptyRound(), emptyRound()],
+      rounds: [round(), round()],
       trailingRounds: 0,
       gameEffects: {},
       gremlins: {

--- a/src/state/gremlins.spec.ts
+++ b/src/state/gremlins.spec.ts
@@ -1,4 +1,4 @@
-import { INITIAL_STATE } from '../lib';
+import { createInitialState } from '../lib';
 import { emptyRound } from '../lib/testHelpers';
 import { rollGremlin } from './gremlins';
 import { reset, addRolls } from '../lib/notRandom';
@@ -7,6 +7,7 @@ import type { GameConfig } from './game';
 jest.mock('../lib/random', () => require('../lib/notRandom'));
 
 describe('rollGremlin', () => {
+  const INITIAL_STATE = createInitialState();
   let config: GameConfig;
   beforeEach(() => {
     reset();

--- a/src/state/gremlins.spec.ts
+++ b/src/state/gremlins.spec.ts
@@ -12,15 +12,8 @@ describe('rollGremlin', () => {
   beforeEach(() => {
     reset();
     config = {
-      rounds: [
-        {
-          title: 'FirstRound',
-          description: null,
-          actions: {},
-          effect: () => ({ title: false, gremlinChange: 50 }),
-        },
-        emptyRound(),
-      ],
+      initialScores: { gremlinChange: 50, userStoryChange: 30 },
+      rounds: [emptyRound(), emptyRound()],
       trailingRounds: 0,
       gameEffects: {},
       gremlins: {

--- a/src/state/gremlins.ts
+++ b/src/state/gremlins.ts
@@ -9,20 +9,20 @@ export type GremlinDescription = {
   name: string;
   description?: ReactElement;
 };
-type GremlinImplementation = GremlinDescription & {
-  probability: (state: GameState) => number;
+type GremlinImplementation<GameActionId extends string> = GremlinDescription & {
+  probability: (state: GameState<GameActionId>) => number;
   effect: (
     age: number,
-    finishedActionIds: string[],
+    finishedActionIds: GameActionId[],
   ) => null | Effect | Effect[];
 };
-export type GremlinList = {
-  [key: string]: GremlinImplementation;
+export type GremlinList<GameActionId extends string> = {
+  [key: string]: GremlinImplementation<GameActionId>;
 };
 
-export function rollGremlin(
-  state: GameState,
-  config: GameConfig,
+export function rollGremlin<GameActionId extends string>(
+  state: GameState<GameActionId>,
+  config: GameConfig<GameActionId>,
 ): string | null {
   /* No gremlins in trailing rounds */
   if (state.pastRounds.length + 1 >= config.rounds.length) {
@@ -74,11 +74,11 @@ export function rollGremlin(
   return gremlin?.id || null;
 }
 
-export function getGremlinEffects(
-  round: GameRound,
+export function getGremlinEffects<GameActionId extends string>(
+  round: GameRound<GameActionId>,
   age: number,
-  finishedActionIds: string[],
-  gremlins: GameConfig['gremlins'],
+  finishedActionIds: GameActionId[],
+  gremlins: GameConfig<GameActionId>['gremlins'],
 ): Effect[] {
   if (round.gremlin) {
     const effect = gremlins[round.gremlin].effect(age, finishedActionIds);
@@ -93,10 +93,10 @@ export function getGremlinEffects(
   return [];
 }
 
-export function getGremlin(
-  round: GameRound,
-  gremlins: GameConfig['gremlins'],
-): (GremlinDescription & GremlinImplementation) | undefined {
+export function getGremlin<GameActionId extends string>(
+  round: GameRound<GameActionId>,
+  gremlins: GameConfig<GameActionId>['gremlins'],
+): (GremlinDescription & GremlinImplementation<GameActionId>) | undefined {
   if (!round.gremlin) {
     return;
   }

--- a/src/state/round.ts
+++ b/src/state/round.ts
@@ -11,13 +11,14 @@ import { getGremlin, GremlinDescription } from './gremlins';
 import { ReactNode } from 'react';
 import { GameAction } from './gameActions/types';
 
-export type GameRound<GameActionId extends string> = {
-  gremlin: string | null;
+export type GameRound<GameActionId extends string, GremlinId extends string> = {
+  gremlin: GremlinId | null;
   selectedGameActionIds: GameActionId[];
 };
-export type ClosedGameRound<GameActionId extends string = string> = GameRound<
-  GameActionId
-> & {
+export type ClosedGameRound<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+> = GameRound<GameActionId, GremlinId> & {
   storiesCompleted: number;
 };
 export type AppRound<GameActionId extends string = string> = {
@@ -37,20 +38,24 @@ export type AppRound<GameActionId extends string = string> = {
   activeEffects: VisibleEffect[];
 };
 
-export function createRound<GameActionId extends string = string>(
-  gremlin: string | null,
-): GameRound<GameActionId> {
+export function createRound<
+  GameActionId extends string = string,
+  GremlinId extends string = string
+>(gremlin: GremlinId | null): GameRound<GameActionId, GremlinId> {
   return {
     gremlin,
     selectedGameActionIds: [],
   };
 }
 
-export function getActionEffects<GameActionId extends string>(
-  round: ClosedGameRound<GameActionId>,
+export function getActionEffects<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  round: ClosedGameRound<GameActionId, GremlinId>,
   age: number,
   finishedActionIds: GameActionId[],
-  rounds: GameConfig<GameActionId>['rounds'],
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ): Effect[] {
   const effects: Effect[] = [];
   round.selectedGameActionIds.forEach((id) => {
@@ -59,9 +64,9 @@ export function getActionEffects<GameActionId extends string>(
   return effects;
 }
 
-export function getCosts<GameActionId extends string>(
-  round: GameRound<GameActionId>,
-  rounds: GameConfig<GameActionId>['rounds'],
+export function getCosts<GameActionId extends string, GremlinId extends string>(
+  round: GameRound<GameActionId, GremlinId>,
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ) {
   return sumByProp(
     round.selectedGameActionIds.map((id) => ({
@@ -71,10 +76,13 @@ export function getCosts<GameActionId extends string>(
   );
 }
 
-export function closeRound<GameActionId extends string>(
-  state: GameState<GameActionId>,
-  config: GameConfig<GameActionId>,
-): ClosedGameRound<GameActionId> {
+export function closeRound<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: GameState<GameActionId, GremlinId>,
+  config: GameConfig<GameActionId, GremlinId>,
+): ClosedGameRound<GameActionId, GremlinId> {
   const effects = getAllEffects(state, config);
   const storiesAttempted =
     getCapacity(effects) - getCosts(state.currentRound, config.rounds);
@@ -96,9 +104,15 @@ function orZero(num: number): number {
   return num < 0 ? 0 : num;
 }
 
-export function deriveAppRound<GameActionId extends string>(
-  state: Pick<GameState<GameActionId>, 'currentRound' | 'pastRounds'>,
-  config: GameConfig<GameActionId>,
+export function deriveAppRound<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: Pick<
+    GameState<GameActionId, GremlinId>,
+    'currentRound' | 'pastRounds'
+  >,
+  config: GameConfig<GameActionId, GremlinId>,
 ): AppRound<GameActionId> {
   const finishedActionIds = concatByProp(
     state.pastRounds,

--- a/src/state/round.ts
+++ b/src/state/round.ts
@@ -11,21 +11,23 @@ import { getGremlin, GremlinDescription } from './gremlins';
 import { ReactNode } from 'react';
 import { GameAction } from './gameActions/types';
 
-export type GameRound = {
+export type GameRound<GameActionId extends string> = {
   gremlin: string | null;
-  selectedGameActionIds: string[];
+  selectedGameActionIds: GameActionId[];
 };
-export type ClosedGameRound = GameRound & {
+export type ClosedGameRound<GameActionId extends string = string> = GameRound<
+  GameActionId
+> & {
   storiesCompleted: number;
 };
-export type AppRound = {
+export type AppRound<GameActionId extends string = string> = {
   number: number;
   title?: string;
   gremlin?: GremlinDescription & {
     effect: VisibleEffect[];
   };
   description?: ReactNode;
-  selectedGameActions: GameAction[];
+  selectedGameActions: GameAction<GameActionId>[];
   capacity: {
     available: number;
     total: number;
@@ -35,18 +37,20 @@ export type AppRound = {
   activeEffects: VisibleEffect[];
 };
 
-export function createRound(gremlin: string | null): GameRound {
+export function createRound<GameActionId extends string = string>(
+  gremlin: string | null,
+): GameRound<GameActionId> {
   return {
     gremlin,
     selectedGameActionIds: [],
   };
 }
 
-export function getActionEffects(
-  round: ClosedGameRound,
+export function getActionEffects<GameActionId extends string>(
+  round: ClosedGameRound<GameActionId>,
   age: number,
-  finishedActionIds: string[],
-  rounds: GameConfig['rounds'],
+  finishedActionIds: GameActionId[],
+  rounds: GameConfig<GameActionId>['rounds'],
 ): Effect[] {
   const effects: Effect[] = [];
   round.selectedGameActionIds.forEach((id) => {
@@ -55,7 +59,10 @@ export function getActionEffects(
   return effects;
 }
 
-export function getCosts(round: GameRound, rounds: GameConfig['rounds']) {
+export function getCosts<GameActionId extends string>(
+  round: GameRound<GameActionId>,
+  rounds: GameConfig<GameActionId>['rounds'],
+) {
   return sumByProp(
     round.selectedGameActionIds.map((id) => ({
       cost: getActionCost(findGameActionById(id, rounds)),
@@ -64,10 +71,10 @@ export function getCosts(round: GameRound, rounds: GameConfig['rounds']) {
   );
 }
 
-export function closeRound(
-  state: GameState,
-  config: GameConfig,
-): ClosedGameRound {
+export function closeRound<GameActionId extends string>(
+  state: GameState<GameActionId>,
+  config: GameConfig<GameActionId>,
+): ClosedGameRound<GameActionId> {
   const effects = getAllEffects(state, config);
   const storiesAttempted =
     getCapacity(effects) - getCosts(state.currentRound, config.rounds);
@@ -89,10 +96,10 @@ function orZero(num: number): number {
   return num < 0 ? 0 : num;
 }
 
-export function deriveAppRound(
-  state: Pick<GameState, 'currentRound' | 'pastRounds'>,
-  config: GameConfig,
-): AppRound {
+export function deriveAppRound<GameActionId extends string>(
+  state: Pick<GameState<GameActionId>, 'currentRound' | 'pastRounds'>,
+  config: GameConfig<GameActionId>,
+): AppRound<GameActionId> {
   const finishedActionIds = concatByProp(
     state.pastRounds,
     'selectedGameActionIds',

--- a/src/state/rounds/getRoundEffects.ts
+++ b/src/state/rounds/getRoundEffects.ts
@@ -1,9 +1,15 @@
 import { Effect, isEffect } from '../effects';
 import { GameState, GameConfig } from '../game';
 
-export function getRoundEffects<GameActionId extends string>(
-  state: Pick<GameState<GameActionId>, 'currentRound' | 'pastRounds'>,
-  rounds: GameConfig<GameActionId>['rounds'],
+export function getRoundEffects<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: Pick<
+    GameState<GameActionId, GremlinId>,
+    'currentRound' | 'pastRounds'
+  >,
+  rounds: GameConfig<GameActionId, GremlinId>['rounds'],
 ): Effect[] {
   const currentRoundIndex = state.pastRounds.length;
   const roundEffects: (null | Effect)[] = [];

--- a/src/state/rounds/getRoundEffects.ts
+++ b/src/state/rounds/getRoundEffects.ts
@@ -1,9 +1,9 @@
 import { Effect, isEffect } from '../effects';
 import { GameState, GameConfig } from '../game';
 
-export function getRoundEffects(
-  state: Pick<GameState, 'currentRound' | 'pastRounds'>,
-  rounds: GameConfig['rounds'],
+export function getRoundEffects<GameActionId extends string>(
+  state: Pick<GameState<GameActionId>, 'currentRound' | 'pastRounds'>,
+  rounds: GameConfig<GameActionId>['rounds'],
 ): Effect[] {
   const currentRoundIndex = state.pastRounds.length;
   const roundEffects: (null | Effect)[] = [];

--- a/src/state/rounds/types.ts
+++ b/src/state/rounds/types.ts
@@ -3,12 +3,15 @@ import { GameActionList } from '../gameActions/types';
 import { Effect } from '../effects/types';
 import { GameRound } from '../round';
 
-export type RoundDescription = {
+export type RoundDescription<
+  RoundActionId extends string,
+  GameActionId extends string
+> = {
   description: ReactNode;
   title: string;
-  actions: GameActionList;
+  actions: GameActionList<RoundActionId, GameActionId>;
   effect?: (
-    previousRounds: GameRound[],
+    previousRounds: GameRound<GameActionId>[],
     currentRound: number,
   ) => Effect | Effect[] | null;
 };

--- a/src/state/rounds/types.ts
+++ b/src/state/rounds/types.ts
@@ -5,13 +5,14 @@ import { GameRound } from '../round';
 
 export type RoundDescription<
   RoundActionId extends string,
-  GameActionId extends string
+  GameActionId extends string,
+  GremlinId extends string
 > = {
   description: ReactNode;
   title: string;
   actions: GameActionList<RoundActionId, GameActionId>;
   effect?: (
-    previousRounds: GameRound<GameActionId>[],
+    previousRounds: GameRound<GameActionId, GremlinId>[],
     currentRound: number,
   ) => Effect | Effect[] | null;
 };


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/generic-game-action-id"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

This refactors the state typings to accept literal `GameActionId` and `GremlinId`

Also makes initial scores [explicit again in config](https://github.com/mlevison/high-performance-teams-game/blob/generic-game-action-id/src/config/index.ts#L11-L26)

---

In order to not cause merge-conflicts I added another change:

- I removed most of the `jest.mock` stuff from tests and used  `GameConfig` variants that only contain the effects we aim to test.

For example, in the test for round4

- no gremlins are configured
- no gameEffects are configured
- all other rounds are empty placeholders
- except for their actions, they exist but also their effects are removed
