### PR TITLE
do not solve solve gemlins with actions taken after the incident

### DIFF
--- a/src/config/gremlins/gremlins.spec.ts
+++ b/src/config/gremlins/gremlins.spec.ts
@@ -108,19 +108,19 @@ describe('Gremlins', () => {
       ]);
     });
 
-    // it('adding protected by outside distractions after the fact has no effect', () => {
-    //   const game = getGame();
+    it('adding protected by outside distractions after the fact has no effect', () => {
+      const game = getGame(gremlinTestConfig);
 
-    //   game.nextRound('GREMLIN_MANAGEMENT_YELLS');
-    //   testCurrentRound(game, { capacityChange: -2, userStoryChange: 0 });
-    //   game.nextRound();
-    //   game.selectAction('PROTECTED_FROM_OUTSIDE_DISTRACTION');
+      game.nextRound('GREMLIN_MANAGEMENT_YELLS');
+      testCurrentRound(game, { capacityChange: -2, userStoryChange: 0 });
+      game.nextRound();
+      game.selectAction('PROTECTED_FROM_OUTSIDE_DISTRACTION');
 
-    //   testFutureRounds(game, [
-    //     { capacityChange: -2, userStoryChange: 0 },
-    //     { capacityChange: -2, userStoryChange: 0 },
-    //   ]);
-    // });
+      testFutureRounds(game, [
+        { capacityChange: -2, userStoryChange: 0 },
+        { capacityChange: -2, userStoryChange: 0 },
+      ]);
+    });
   });
 
   describe('Team Member not pulling their weight', () => {

--- a/src/config/gremlins/gremlins.tsx
+++ b/src/config/gremlins/gremlins.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { GameActionId } from '../rounds';
 import type { GremlinList } from '../../state';
+import { selectedActionIds } from '../../lib';
 
 export type GremlinId =
   | 'GREMLIN_MANAGEMENT_YELLS'
@@ -26,9 +27,15 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         eliminate the effect.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_MANAGEMENT_YELLS',
+      );
+
       let name = 'Management yells at a team member in public';
-      if (finishedActionIds.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION')) {
+      if (preparations.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION')) {
         return { capacityChange: -1, title: name };
       }
       return {
@@ -47,10 +54,16 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         Protection from Outside Distraction, they will reduce effects.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_EMERGENCY_ON_OTHER_TEAM',
+      );
+
       if (
         age >= 3 ||
-        (finishedActionIds.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION') &&
+        (preparations.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION') &&
           age >= 2)
       ) {
         return null;
@@ -58,10 +71,10 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
 
       let capacity = -3;
 
-      if (finishedActionIds.includes('CROSS_SKILLING')) {
+      if (preparations.includes('CROSS_SKILLING')) {
         capacity += 1;
       }
-      if (finishedActionIds.includes('EXTERNAL_CROSS_TRAINING')) {
+      if (preparations.includes('EXTERNAL_CROSS_TRAINING')) {
         capacity += 1;
       }
 
@@ -86,11 +99,17 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         because they see others and learn from them.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_NOT_PULLING_THEIR_WEIGHT',
+      );
+
       let capacityChange = -2;
       if (
-        finishedActionIds.includes('ONE_ON_ONES') ||
-        finishedActionIds.includes('CROSS_SKILLING')
+        preparations.includes('ONE_ON_ONES') ||
+        preparations.includes('CROSS_SKILLING')
       ) {
         capacityChange = -1;
       }
@@ -112,11 +131,17 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         team members to raise the issue.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_NOT_AT_DAILY_SCRUM',
+      );
+
       let capacityChange = -1;
       if (
-        finishedActionIds.includes('ONE_ON_ONES') ||
-        finishedActionIds.includes('WORKING_AGREEMENTS')
+        preparations.includes('ONE_ON_ONES') ||
+        preparations.includes('WORKING_AGREEMENTS')
       ) {
         capacityChange = 0;
       }
@@ -138,10 +163,16 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         continually stay up to date on the Product Owners needs
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_NEW_STORY_MID_SPRINT',
+      );
+
       if (
-        finishedActionIds.includes('BACKLOG_REFINEMENT') &&
-        finishedActionIds.includes('STORY_MAPPING_OR_OTHER')
+        preparations.includes('BACKLOG_REFINEMENT') &&
+        preparations.includes('STORY_MAPPING_OR_OTHER')
       ) {
         return {
           capacityChange: 0,
@@ -150,10 +181,11 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
             'Emergency Story Mid-Sprint effect avoided by the combined effect of Ongoing Backlog Refinement and good Strategic work with the Product Owner',
         };
       }
+
       if (age === 0) {
         if (
-          finishedActionIds.includes('BACKLOG_REFINEMENT') ||
-          finishedActionIds.includes('STORY_MAPPING_OR_OTHER')
+          preparations.includes('BACKLOG_REFINEMENT') ||
+          preparations.includes('STORY_MAPPING_OR_OTHER')
         ) {
           return {
             capacityChange: -1,
@@ -169,6 +201,7 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
           title: 'Emergency Story Mid-Sprint is hurting',
         };
       }
+
       return {
         capacityChange: 0,
         userStoryChange: 0,
@@ -188,19 +221,25 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         Backlog size avoid this problem altogether.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_PRODUCT_BACKLOG_MESS',
+      );
+
       let additionalComment = '';
       let capacityChange = -1;
       let userStoryChange = -20;
       if (
-        finishedActionIds.includes('STORY_MAPPING_OR_OTHER') ||
-        finishedActionIds.includes('BACKLOG_REFINEMENT')
+        preparations.includes('STORY_MAPPING_OR_OTHER') ||
+        preparations.includes('BACKLOG_REFINEMENT')
       ) {
         userStoryChange = -10;
         additionalComment =
           '- Story Mapping or Backlog Refinement reduce the effect';
       }
-      if (finishedActionIds.includes('WORK_WITH_PO_LIMIT_PB_SIZE')) {
+      if (preparations.includes('WORK_WITH_PO_LIMIT_PB_SIZE')) {
         capacityChange = 0;
         userStoryChange = 0;
         additionalComment =
@@ -224,7 +263,9 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         the problem
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const finishedActionIds = selectedActionIds(state);
+
       if (
         finishedActionIds.includes('IMPROVE_RETROSPECTIVES_CHANGE_AGENDA') ||
         finishedActionIds.includes('IMPROVE_RETROSPECTIVES_CONCRETE_ACTIONS')
@@ -256,21 +297,27 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         suffer this effect less.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_POOR_QUALITY',
+      );
+
       let additionalComment = '';
       let capacityChange = -3;
       let userStoryChange = -15;
       if (
-        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') ||
-        finishedActionIds.includes('PAIR_PROGRAMMING')
+        preparations.includes('TEST_DRIVEN_DEVELOPMENT') ||
+        preparations.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -2;
         userStoryChange = -10;
         additionalComment = '- TDD or Pair Programming Reduce the effect';
       }
       if (
-        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') &&
-        finishedActionIds.includes('PAIR_PROGRAMMING')
+        preparations.includes('TEST_DRIVEN_DEVELOPMENT') &&
+        preparations.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -1;
         userStoryChange = -5;
@@ -278,7 +325,7 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
           '- TDD and Pair Programming Reduce elimintate the effect';
       }
 
-      if (finishedActionIds.includes('ADOPT_BDD')) {
+      if (preparations.includes('ADOPT_BDD')) {
         capacityChange = -1;
         userStoryChange = -5;
         additionalComment = '- BDD Reduced the effect';
@@ -301,19 +348,25 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
         Programming suffer this effect less.
       </p>
     ),
-    effect(age, finishedActionIds) {
+    effect(age, state) {
+      const preparations = selectedActionIds(
+        state,
+        /* before this gremlin ocurred */ (round) =>
+          round.gremlin === 'GREMLIN_UNREADABLE_CODE',
+      );
+
       let additionalComment = '';
       let capacityChange = -2;
       if (
-        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') ||
-        finishedActionIds.includes('PAIR_PROGRAMMING')
+        preparations.includes('TEST_DRIVEN_DEVELOPMENT') ||
+        preparations.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -1;
         additionalComment = '- TDD or Pair Programming Reduce the effect';
       }
       if (
-        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') &&
-        finishedActionIds.includes('PAIR_PROGRAMMING')
+        preparations.includes('TEST_DRIVEN_DEVELOPMENT') &&
+        preparations.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = 0;
         additionalComment =

--- a/src/config/gremlins/gremlins.tsx
+++ b/src/config/gremlins/gremlins.tsx
@@ -55,15 +55,11 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_EMERGENCY_ON_OTHER_TEAM',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       if (
         age >= 3 ||
-        (preparations.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION') &&
+        (finishedActionIds.includes('PROTECTED_FROM_OUTSIDE_DISTRACTION') &&
           age >= 2)
       ) {
         return null;
@@ -71,10 +67,10 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
 
       let capacity = -3;
 
-      if (preparations.includes('CROSS_SKILLING')) {
+      if (finishedActionIds.includes('CROSS_SKILLING')) {
         capacity += 1;
       }
-      if (preparations.includes('EXTERNAL_CROSS_TRAINING')) {
+      if (finishedActionIds.includes('EXTERNAL_CROSS_TRAINING')) {
         capacity += 1;
       }
 
@@ -100,16 +96,12 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_NOT_PULLING_THEIR_WEIGHT',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       let capacityChange = -2;
       if (
-        preparations.includes('ONE_ON_ONES') ||
-        preparations.includes('CROSS_SKILLING')
+        finishedActionIds.includes('ONE_ON_ONES') ||
+        finishedActionIds.includes('CROSS_SKILLING')
       ) {
         capacityChange = -1;
       }
@@ -132,16 +124,12 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_NOT_AT_DAILY_SCRUM',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       let capacityChange = -1;
       if (
-        preparations.includes('ONE_ON_ONES') ||
-        preparations.includes('WORKING_AGREEMENTS')
+        finishedActionIds.includes('ONE_ON_ONES') ||
+        finishedActionIds.includes('WORKING_AGREEMENTS')
       ) {
         capacityChange = 0;
       }
@@ -164,15 +152,11 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_NEW_STORY_MID_SPRINT',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       if (
-        preparations.includes('BACKLOG_REFINEMENT') &&
-        preparations.includes('STORY_MAPPING_OR_OTHER')
+        finishedActionIds.includes('BACKLOG_REFINEMENT') &&
+        finishedActionIds.includes('STORY_MAPPING_OR_OTHER')
       ) {
         return {
           capacityChange: 0,
@@ -184,8 +168,8 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
 
       if (age === 0) {
         if (
-          preparations.includes('BACKLOG_REFINEMENT') ||
-          preparations.includes('STORY_MAPPING_OR_OTHER')
+          finishedActionIds.includes('BACKLOG_REFINEMENT') ||
+          finishedActionIds.includes('STORY_MAPPING_OR_OTHER')
         ) {
           return {
             capacityChange: -1,
@@ -222,24 +206,20 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_PRODUCT_BACKLOG_MESS',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       let additionalComment = '';
       let capacityChange = -1;
       let userStoryChange = -20;
       if (
-        preparations.includes('STORY_MAPPING_OR_OTHER') ||
-        preparations.includes('BACKLOG_REFINEMENT')
+        finishedActionIds.includes('STORY_MAPPING_OR_OTHER') ||
+        finishedActionIds.includes('BACKLOG_REFINEMENT')
       ) {
         userStoryChange = -10;
         additionalComment =
           '- Story Mapping or Backlog Refinement reduce the effect';
       }
-      if (preparations.includes('WORK_WITH_PO_LIMIT_PB_SIZE')) {
+      if (finishedActionIds.includes('WORK_WITH_PO_LIMIT_PB_SIZE')) {
         capacityChange = 0;
         userStoryChange = 0;
         additionalComment =
@@ -298,26 +278,22 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_POOR_QUALITY',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       let additionalComment = '';
       let capacityChange = -3;
       let userStoryChange = -15;
       if (
-        preparations.includes('TEST_DRIVEN_DEVELOPMENT') ||
-        preparations.includes('PAIR_PROGRAMMING')
+        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') ||
+        finishedActionIds.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -2;
         userStoryChange = -10;
         additionalComment = '- TDD or Pair Programming Reduce the effect';
       }
       if (
-        preparations.includes('TEST_DRIVEN_DEVELOPMENT') &&
-        preparations.includes('PAIR_PROGRAMMING')
+        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') &&
+        finishedActionIds.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -1;
         userStoryChange = -5;
@@ -325,7 +301,7 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
           '- TDD and Pair Programming Reduce elimintate the effect';
       }
 
-      if (preparations.includes('ADOPT_BDD')) {
+      if (finishedActionIds.includes('ADOPT_BDD')) {
         capacityChange = -1;
         userStoryChange = -5;
         additionalComment = '- BDD Reduced the effect';
@@ -349,24 +325,20 @@ export const gremlins: GremlinList<GremlinId, GameActionId> = {
       </p>
     ),
     effect(age, state) {
-      const preparations = selectedActionIds(
-        state,
-        /* before this gremlin ocurred */ (round) =>
-          round.gremlin === 'GREMLIN_UNREADABLE_CODE',
-      );
+      const finishedActionIds = selectedActionIds(state);
 
       let additionalComment = '';
       let capacityChange = -2;
       if (
-        preparations.includes('TEST_DRIVEN_DEVELOPMENT') ||
-        preparations.includes('PAIR_PROGRAMMING')
+        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') ||
+        finishedActionIds.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = -1;
         additionalComment = '- TDD or Pair Programming Reduce the effect';
       }
       if (
-        preparations.includes('TEST_DRIVEN_DEVELOPMENT') &&
-        preparations.includes('PAIR_PROGRAMMING')
+        finishedActionIds.includes('TEST_DRIVEN_DEVELOPMENT') &&
+        finishedActionIds.includes('PAIR_PROGRAMMING')
       ) {
         capacityChange = 0;
         additionalComment =

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,3 +8,4 @@ export * from './isGameActionWithImage';
 export * from './initialState';
 export * from './useAppState';
 export * from './uiState';
+export * from './selectedActionIds';

--- a/src/lib/selectedActionIds.ts
+++ b/src/lib/selectedActionIds.ts
@@ -1,0 +1,32 @@
+import { ClosedRound, GameRound, GameState } from '../state';
+export function selectedActionIds<
+  GameActionId extends string,
+  GremlinId extends string
+>(
+  state: Pick<
+    GameState<GameActionId, GremlinId>,
+    'currentRound' | 'pastRounds'
+  >,
+  before?: (
+    round:
+      | ClosedRound<GameActionId, GremlinId>
+      | GameRound<GameActionId, GremlinId>,
+  ) => boolean,
+) {
+  const selectedActions: GameActionId[] = [];
+  let stop = false;
+  for (let i = 0; i < state.pastRounds.length; i++) {
+    const round = state.pastRounds[i];
+    stop = before?.(round) || false;
+    if (stop) {
+      break;
+    } else {
+      selectedActions.push(...round.selectedGameActionIds);
+    }
+  }
+  if (!stop) {
+    selectedActions.push(...state.currentRound.selectedGameActionIds);
+  }
+
+  return selectedActions;
+}

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -113,12 +113,7 @@ export function getAllEffects<
 
   /* current rounds gremlin */
   effects.push(
-    ...getGremlinEffects(
-      state.currentRound,
-      0,
-      finishedActionIds,
-      config.gremlins,
-    ),
+    ...getGremlinEffects(state.currentRound, 0, config.gremlins, state),
   );
 
   /* Get action and gremlin effects from past rounds */
@@ -128,7 +123,7 @@ export function getAllEffects<
 
     effects.push(
       /* gremlins occur on current round, so they're at age +1 in next */
-      ...getGremlinEffects(round, age, finishedActionIds, config.gremlins),
+      ...getGremlinEffects(round, age, config.gremlins, state),
       /* actions get active in next */
       ...getActionEffects(round, age, finishedActionIds, config.rounds).filter(
         isEffect,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,5 +1,9 @@
 export type { Action } from './game';
-export type { ClosedGameRound as ClosedRound, AppRound } from './round';
+export type {
+  ClosedGameRound as ClosedRound,
+  GameRound,
+  AppRound,
+} from './round';
 export type {
   GameState,
   GameActionAction,

--- a/src/state/round.ts
+++ b/src/state/round.ts
@@ -128,7 +128,7 @@ export function deriveAppRound<
   const currentRoundTitle = config.rounds[currentRoundIndex]?.title;
   const currentRoundDescription = config.rounds[currentRoundIndex]?.description;
   const gremlin = getGremlin(state.currentRound, config.gremlins);
-  const gremlinEffect = gremlin?.effect(0, finishedActionIds) || null;
+  const gremlinEffect = gremlin?.effect(0, state) || null;
   const visibleGremlinEffects = (Array.isArray(gremlinEffect)
     ? gremlinEffect
     : [gremlinEffect]


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/do-not-solve-gremlins-later"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

I changed all the implementations to not take future actions into account except `GREMLIN_SKIP_RETRO` since its tests specified otherwise.

@mlevison please review if any of the gremlins should actually take future actions into account 