### PR TITLE
Simulate more

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - uses: actions/cache@v2
         id: npm-v1

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # simulation results
 /src/simulate/results.json
+/src/simulate/results/*
+!/src/simulate/results/.gitkeep
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "high-performance-teams-game",
       "version": "0.1.0",
       "dependencies": {
         "@popperjs/core": "2.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "cli-progress": "3.9.0",
         "concurrently": "5.3.0",
         "cross-env": "7.0.3",
+        "csv-stringify": "6.0.4",
         "decorate-gh-pr": "1.3.1",
         "get-port": "5.1.1",
         "gh-pages": "3.1.0",
@@ -5951,6 +5952,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
       "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.4.tgz",
+      "integrity": "sha512-Z3EbRQWwkOV3Qc2fQnJmfjrxRgAwH9AncnNK2jmtTvBvFjj/hESZUGm42YvTh9kMw2OOGPHQn5Yt0EbqoRtUVQ=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -26705,6 +26711,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
       "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+    },
+    "csv-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.4.tgz",
+      "integrity": "sha512-Z3EbRQWwkOV3Qc2fQnJmfjrxRgAwH9AncnNK2jmtTvBvFjj/hESZUGm42YvTh9kMw2OOGPHQn5Yt0EbqoRtUVQ=="
     },
     "cyclist": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cli-progress": "3.9.0",
     "concurrently": "5.3.0",
     "cross-env": "7.0.3",
+    "csv-stringify": "6.0.4",
     "decorate-gh-pr": "1.3.1",
     "get-port": "5.1.1",
     "gh-pages": "3.1.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { GameConfig } from '../state';
 import {
   Results,
@@ -182,6 +182,19 @@ export default function OutdatedStateWarning(props: {
 }) {
   const version = useVersion();
   const [initialState, setInitialState] = useState(props.initialState);
+  const configOverwrites = initialState.config;
+  const config = props.config;
+  const mergedConfig = useMemo(
+    () => ({
+      ...config,
+      ...configOverwrites,
+      initialScores: {
+        ...config.initialScores,
+        ...configOverwrites.initialScores,
+      },
+    }),
+    [config, configOverwrites],
+  );
   if (!version) {
     return null;
   }
@@ -211,7 +224,11 @@ export default function OutdatedStateWarning(props: {
           </Button>
           <Button
             onClick={() => {
-              saveToLocalStorage(initialState.state, version);
+              saveToLocalStorage(
+                initialState.state,
+                version,
+                initialState.config,
+              );
               window.location.href = window.location.href.split('?')[0];
             }}
             primary
@@ -224,7 +241,7 @@ export default function OutdatedStateWarning(props: {
   }
 
   if (initialState.status === GAME_STATE_OK) {
-    return <App initialState={initialState.state} config={props.config} />;
+    return <App initialState={initialState.state} config={mergedConfig} />;
   }
 
   return (
@@ -240,6 +257,7 @@ export default function OutdatedStateWarning(props: {
           onClick={() =>
             setInitialState({
               state: initialState.state,
+              config: props.initialState.config,
               status: GAME_STATE_OK,
             })
           }
@@ -250,6 +268,7 @@ export default function OutdatedStateWarning(props: {
           onClick={() =>
             setInitialState({
               state: createInitialState(),
+              config: props.initialState.config,
               status: GAME_STATE_OK,
             })
           }

--- a/src/lib/persistState.ts
+++ b/src/lib/persistState.ts
@@ -101,6 +101,20 @@ export function useVersion() {
   return version;
 }
 
+export function stateLink(
+  origin: string,
+  version: string | null,
+  state: AppBaseState,
+  from: number = new Date().getTime(),
+  config: OverwritableConfig = {},
+) {
+  return `${origin}?restore=${encodeURIComponent(
+    btoa(JSON.stringify({ state, config })),
+  )}${
+    version ? `&version=${encodeURIComponent(version)}` : ''
+  }&from=${encodeURIComponent(from)}`;
+}
+
 export function useStateLink(
   state: AppBaseState,
   from: number = new Date().getTime(),
@@ -108,11 +122,7 @@ export function useStateLink(
 ) {
   const version = useVersion();
 
-  return `${window.location.origin}?restore=${encodeURIComponent(
-    btoa(JSON.stringify({ state, config })),
-  )}${
-    version ? `&version=${encodeURIComponent(version)}` : ''
-  }&from=${encodeURIComponent(from)}`;
+  return stateLink(window.location.origin, version, state, from, config);
 }
 
 export function saveToLocalStorage(

--- a/src/simulate/ResultsApp.tsx
+++ b/src/simulate/ResultsApp.tsx
@@ -90,7 +90,7 @@ function GameLink({
     () => ({ ...state, ui: { view: 'actions', review: 0 } }),
     [state],
   );
-  const href = useStateLink(baseState, finished);
+  const href = useStateLink(baseState, finished, results.simulateConfig);
   return (
     <a href={href} target="_blank" rel="noreferrer">
       {children}

--- a/src/simulate/ResultsApp.tsx
+++ b/src/simulate/ResultsApp.tsx
@@ -23,6 +23,7 @@ const SELECTED_ACTIONS = 'Actions selected throughout game';
 const OCURRED_GREMLINS = 'Gremlins ocurred throughout game';
 const STORIES_ATTEMPTED = 'Total user stories attempted';
 const STORIES_COMPLETED = 'Total user stories completed';
+const COMBINED_SCORE = 'Combined Score';
 
 type ScoreKey =
   | typeof TOTAL_CAPACITY
@@ -31,7 +32,8 @@ type ScoreKey =
   | typeof SELECTED_ACTIONS
   | typeof OCURRED_GREMLINS
   | typeof STORIES_ATTEMPTED
-  | typeof STORIES_COMPLETED;
+  | typeof STORIES_COMPLETED
+  | typeof COMBINED_SCORE;
 const SCOREKEY_MAP: ScoreKey[] = [
   TOTAL_CAPACITY,
   FINAL_GREMLIN_CHANCE,
@@ -40,6 +42,7 @@ const SCOREKEY_MAP: ScoreKey[] = [
   OCURRED_GREMLINS,
   STORIES_ATTEMPTED,
   STORIES_COMPLETED,
+  COMBINED_SCORE,
 ];
 const OPTIONS: { [K in ScoreKey]: Partial<LineProps> } = {
   [TOTAL_CAPACITY]: {
@@ -71,6 +74,10 @@ const OPTIONS: { [K in ScoreKey]: Partial<LineProps> } = {
   [STORIES_COMPLETED]: {
     yAxisId: 'stories',
     stroke: '#1be400',
+  },
+  [COMBINED_SCORE]: {
+    yAxisId: 'combinedScore',
+    stroke: '#7600e4',
   },
 };
 const yAxis = Array.from(
@@ -108,11 +115,16 @@ export default function ResultsApp() {
     return results.data
       .map((data, id) => ({ id, data }))
       .sort((a, b) => {
-        const val = a.data[sortIndex] - b.data[sortIndex];
-        if (val === 0) {
-          return a.id - b.id;
+        const sort = a.data[sortIndex] - b.data[sortIndex];
+        const scombinedScoreSort = a.data[7] - b.data[7];
+        switch (true) {
+          case sort !== 0:
+            return sort;
+          case scombinedScoreSort !== 0:
+            return scombinedScoreSort;
+          default:
+            return a.id - b.id;
         }
-        return val;
       })
       .filter((_, i) => {
         const t = i / showQuota;
@@ -127,6 +139,7 @@ export default function ResultsApp() {
         [OCURRED_GREMLINS]: data[4],
         [STORIES_ATTEMPTED]: data[5],
         [STORIES_COMPLETED]: data[6],
+        [COMBINED_SCORE]: data[7],
       }));
   }, [showAmount, sortBy]);
 

--- a/src/simulate/actionSelectors.ts
+++ b/src/simulate/actionSelectors.ts
@@ -1,0 +1,67 @@
+import { GameActionId } from '../config';
+import { AppRound, GameState, GameAction } from '../state';
+
+type ActionSelector = (
+  selectableGameActions: GameAction<GameActionId>[],
+  round: AppRound<GameActionId>,
+  state: GameState<GameActionId>,
+) => GameAction<GameActionId> | null;
+
+/**
+ * Select 3 random actions each round when possible
+ */
+export const always3: ActionSelector = (selectableGameActions, round) => {
+  if (round.selectedGameActions.length < 3 && selectableGameActions.length) {
+    return selectableGameActions[
+      Math.floor(Math.random() * selectableGameActions.length)
+    ];
+  }
+
+  return null;
+};
+
+/**
+ * Select actions when possible and move to next round with
+ * the same chance of selecting a single action
+ */
+export const greedy: ActionSelector = (selectableGameActions, round) => {
+  return (
+    selectableGameActions[
+      Math.floor(Math.random() * (selectableGameActions.length + 1))
+    ] || null
+  );
+};
+
+/**
+ * Always spend 30% of capacity on improvements
+ */
+export const byPercent: ActionSelector = (selectableGameActions, round) => {
+  const targetPercent = 0.3;
+  const targetPointsForActions = Math.round(
+    round.capacity.total * targetPercent,
+  );
+  const spendOnActions = round.capacity.total - round.capacity.available;
+  const availableForActions = targetPointsForActions - spendOnActions;
+
+  const potentialActions = selectableGameActions.filter(
+    ({ cost }) => cost <= availableForActions,
+  );
+
+  if (!potentialActions.length) {
+    return null;
+  }
+
+  return potentialActions[Math.floor(Math.random() * potentialActions.length)];
+};
+
+/**
+ * 30% chance to to to next round with each decision
+ */
+export const byChance: ActionSelector = (selectableGameActions) => {
+  if (Math.random() > 0.35 && selectableGameActions.length) {
+    return selectableGameActions[
+      Math.floor(Math.random() * selectableGameActions.length)
+    ];
+  }
+  return null;
+};

--- a/src/simulate/index.ts
+++ b/src/simulate/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import progress from 'cli-progress';
-import { config, GameActionId, GremlinId } from '../config';
+import { config as originalConfig, GameActionId, GremlinId } from '../config';
+import { simulateConfig } from './simulateConfig';
 import { createInitialState, concatByProp, sumByProp } from '../lib';
 import {
   AppRound,
@@ -13,6 +14,15 @@ import {
   GameState,
   GameAction,
 } from '../state';
+
+const config: typeof originalConfig = {
+  ...originalConfig,
+  ...simulateConfig,
+  initialScores: {
+    ...originalConfig.initialScores,
+    ...simulateConfig.initialScores,
+  },
+};
 
 type ActionSelector = (
   selectableGameActions: GameAction<GameActionId>[],
@@ -208,6 +218,7 @@ const results = {
       { state: sims[i].state, finished: sims[i].finished },
     ]),
   ),
+  simulateConfig,
   data: sims.map(({ final }) => final),
 };
 

--- a/src/simulate/index.ts
+++ b/src/simulate/index.ts
@@ -92,7 +92,7 @@ const actionSelectors: {
   },
 };
 
-const selectGameAction = actionSelectors.byChance;
+const selectGameAction = actionSelectors.always3;
 
 const simulationsInput = parseInt(process.argv[2], 10);
 const simulationsToRun: number =

--- a/src/simulate/index.ts
+++ b/src/simulate/index.ts
@@ -7,6 +7,7 @@ import {
   actionSelector,
   calculateCombinedScore,
   STORE_BEST,
+  INCLUDE_LINK,
   STORE_WORST,
 } from './simulateConfig';
 import { createInitialState, concatByProp, sumByProp, stateLink } from '../lib';
@@ -289,16 +290,18 @@ function getLines(simIds: number[]) {
 
     game.simulationId = id;
     game.simulationTime = new Date(finished).toISOString();
-    game.link = stateLink(
-      'https://teamsgame.agilepainrelief.com',
-      null,
-      {
-        ...state,
-        ui: { view: 'actions', review: 0 },
-      },
-      finished,
-      simulateConfig,
-    );
+    if (INCLUDE_LINK) {
+      game.link = stateLink(
+        'https://teamsgame.agilepainrelief.com',
+        null,
+        {
+          ...state,
+          ui: { view: 'actions', review: 0 },
+        },
+        finished,
+        simulateConfig,
+      );
+    }
     return game;
   });
 }

--- a/src/simulate/index.ts
+++ b/src/simulate/index.ts
@@ -1,10 +1,15 @@
 import fs from 'fs';
 import progress from 'cli-progress';
 import { config as originalConfig, GameActionId, GremlinId } from '../config';
-import { simulateConfig } from './simulateConfig';
+import {
+  simulateConfig,
+  actionSelector,
+  calculateCombinedScore,
+  STORE_BEST,
+  STORE_WORST,
+} from './simulateConfig';
 import { createInitialState, concatByProp, sumByProp } from '../lib';
 import {
-  AppRound,
   createGameReducer,
   closeRound,
   deriveAppRound,
@@ -12,7 +17,6 @@ import {
   getAvailableGameActions,
   rollGremlin,
   GameState,
-  GameAction,
 } from '../state';
 
 const config: typeof originalConfig = {
@@ -23,76 +27,6 @@ const config: typeof originalConfig = {
     ...simulateConfig.initialScores,
   },
 };
-
-type ActionSelector = (
-  selectableGameActions: GameAction<GameActionId>[],
-  round: AppRound<GameActionId>,
-  state: GameState<GameActionId>,
-) => GameAction<GameActionId> | null;
-
-const actionSelectors: {
-  [Key: string]: ActionSelector;
-} = {
-  /**
-   * Select 3 random actions each round when possible
-   */
-  always3(selectableGameActions, round) {
-    if (round.selectedGameActions.length < 3 && selectableGameActions.length) {
-      return selectableGameActions[
-        Math.floor(Math.random() * selectableGameActions.length)
-      ];
-    }
-
-    return null;
-  },
-  /**
-   * Select actions when possible and move to next round with
-   * the same chance of selecting a single action
-   */
-  greedy(selectableGameActions, round) {
-    return (
-      selectableGameActions[
-        Math.floor(Math.random() * (selectableGameActions.length + 1))
-      ] || null
-    );
-  },
-  /**
-   * Always spend 30% of capacity on improvements
-   */
-  byPercent(selectableGameActions, round) {
-    const targetPercent = 0.3;
-    const targetPointsForActions = Math.round(
-      round.capacity.total * targetPercent,
-    );
-    const spendOnActions = round.capacity.total - round.capacity.available;
-    const availableForActions = targetPointsForActions - spendOnActions;
-
-    const potentialActions = selectableGameActions.filter(
-      ({ cost }) => cost <= availableForActions,
-    );
-
-    if (!potentialActions.length) {
-      return null;
-    }
-
-    return potentialActions[
-      Math.floor(Math.random() * potentialActions.length)
-    ];
-  },
-  /**
-   * 30% chance to to to next round with each decision
-   */
-  byChance(selectableGameActions) {
-    if (Math.random() > 0.35 && selectableGameActions.length) {
-      return selectableGameActions[
-        Math.floor(Math.random() * selectableGameActions.length)
-      ];
-    }
-    return null;
-  },
-};
-
-const selectGameAction = actionSelectors.always3;
 
 const simulationsInput = parseInt(process.argv[2], 10);
 const simulationsToRun: number =
@@ -106,26 +40,55 @@ console.log(
 const bar = new progress.SingleBar({}, progress.Presets.shades_classic);
 bar.start(simulationsToRun, 0);
 
-const sims: {
+const FINAL_KEYS = [
+  'capacity' as const,
+  'gremlinChance' as const,
+  'userStoryChance' as const,
+  'selectedActions' as const,
+  'ocurredGremlins' as const,
+  'storiesAttempted' as const,
+  'storiesCompleted' as const,
+  'combinedScore' as const,
+];
+type FinalKeys = typeof FINAL_KEYS;
+
+type Simulation = {
   state: GameState<GameActionId, GremlinId>;
   finished: number;
-  final: [
-    capacity: number,
-    gremlinChance: number,
-    userStoryChance: number,
-    selectedActions: number,
-    ocurredGremlins: number,
-    storiesAttempted: number,
-    storiesCompleted: number,
-  ];
-}[] = [];
+  final: {
+    [K in FinalKeys[0]]: number;
+  };
+};
+
+export type SimulationWithoutCombinedScore = Omit<Simulation, 'final'> & {
+  final: Omit<Simulation['final'], 'combinedScore'>;
+};
+
+const relevantSims: { [K: number]: Simulation } = {};
+const data: number[][] = [];
+const topFlop: {
+  [K in FinalKeys[0]]: {
+    top: number[];
+    flop: number[];
+  };
+} = {
+  capacity: { top: [], flop: [] },
+  gremlinChance: { top: [], flop: [] },
+  userStoryChance: { top: [], flop: [] },
+  selectedActions: { top: [], flop: [] },
+  ocurredGremlins: { top: [], flop: [] },
+  storiesAttempted: { top: [], flop: [] },
+  storiesCompleted: { top: [], flop: [] },
+  combinedScore: { top: [], flop: [] },
+};
+
+const reducer = createGameReducer(
+  config,
+  createInitialState<GameActionId, GremlinId>(),
+);
 
 for (let index = 0; index < simulationsToRun; index++) {
   let state: GameState<GameActionId, GremlinId> = createInitialState();
-  const reducer = createGameReducer(
-    config,
-    createInitialState<GameActionId, GremlinId>(),
-  );
 
   while (
     state.pastRounds.length <
@@ -146,7 +109,7 @@ for (let index = 0; index < simulationsToRun; index++) {
       )
       .map(({ gameAction }) => gameAction);
 
-    const action = selectGameAction(selectableGameActions, round, state);
+    const action = actionSelector(selectableGameActions, round, state);
 
     state = action
       ? reducer(state, { type: 'SELECT_GAME_ACTION', payload: action.id })
@@ -172,54 +135,100 @@ for (let index = 0; index < simulationsToRun; index++) {
   );
   const storiesCompleted = sumByProp(appState.pastRounds, 'storiesCompleted');
 
-  sims.push({
+  const simWithoutCombined: SimulationWithoutCombinedScore = {
     state,
     finished: new Date().getTime(),
-    final: [
-      appState.currentRound.capacity.total,
-      appState.currentRound.gremlinChance,
-      appState.currentRound.userStoryChance,
-      state.pastRounds.reduce(
+    final: {
+      capacity: appState.currentRound.capacity.total,
+      gremlinChance: appState.currentRound.gremlinChance,
+      userStoryChance: appState.currentRound.userStoryChance,
+      selectedActions: state.pastRounds.reduce(
         (i, { selectedGameActionIds }) => i + selectedGameActionIds.length,
         0,
       ),
-      state.pastRounds.filter(({ gremlin }) => gremlin !== null).length,
-      storiesAttempted,
-      storiesCompleted,
-    ],
-  });
+      ocurredGremlins: state.pastRounds.filter(
+        ({ gremlin }) => gremlin !== null,
+      ).length,
+      storiesAttempted: storiesAttempted,
+      storiesCompleted: storiesCompleted,
+    },
+  };
+  registerGame(
+    {
+      ...simWithoutCombined,
+      final: {
+        ...simWithoutCombined.final,
+        combinedScore: calculateCombinedScore(simWithoutCombined),
+      },
+    },
+    index,
+  );
   bar.update(index + 1);
 }
 
 bar.stop();
 
-/* Find Top and Flop games */
-const topFlop: [value: number, id: number][] = [];
-sims.forEach(({ final }, id) => {
-  final.forEach((val, i) => {
-    const t = i * 2;
-    const f = t + 1;
-    if (!topFlop[t] || topFlop[t][0] < val) {
-      topFlop[t] = [val, id];
-    }
+function registerGame(sim: Simulation, i: number) {
+  const outruled: number[] = [];
+  data.push(Object.values(sim.final));
+  FINAL_KEYS.forEach((key) => {
+    relevantSims[i] = sim;
 
-    if (!topFlop[f] || topFlop[f][0] > val) {
-      topFlop[f] = [val, id];
+    topFlop[key].top.push(i);
+    outruled.push(
+      ...topFlop[key].top
+        .sort((ia, ib) => {
+          const {
+            final: { [key]: a, combinedScore: ca },
+          } = relevantSims[ia];
+          const {
+            final: { [key]: b, combinedScore: cb },
+          } = relevantSims[ib];
+          if (a !== b) {
+            return b - a;
+          } else if (cb !== ca) {
+            return cb - ca;
+          }
+          return ib - ia;
+        })
+        .splice(0, topFlop[key].top.length - STORE_BEST),
+    );
+    topFlop[key].flop.push(i);
+    outruled.push(
+      ...topFlop[key].flop
+        .sort((ia, ib) => {
+          const {
+            final: { [key]: a, combinedScore: ca },
+          } = relevantSims[ia];
+          const {
+            final: { [key]: b, combinedScore: cb },
+          } = relevantSims[ib];
+          if (a !== b) {
+            return a - b;
+          } else if (cb !== ca) {
+            return ca - cb;
+          }
+          return ia - ib;
+        })
+        .splice(0, topFlop[key].flop.length - STORE_WORST),
+    );
+  });
+  Array.from(new Set(outruled)).forEach((out) => {
+    const someoneLikesMe = FINAL_KEYS.some(
+      (key) =>
+        topFlop[key].top.includes(out) || topFlop[key].flop.includes(out),
+    );
+    if (!someoneLikesMe) {
+      delete relevantSims[out];
     }
   });
-});
-const relevantGameIndexes = Array.from(new Set(topFlop.map(([_, i]) => i)));
+}
 
 /* Create and wrote Results file */
 const results = {
-  relevantSims: Object.fromEntries(
-    relevantGameIndexes.map((i) => [
-      i,
-      { state: sims[i].state, finished: sims[i].finished },
-    ]),
-  ),
+  relevantSims,
+  data,
   simulateConfig,
-  data: sims.map(({ final }) => final),
 };
 
 export type Results = typeof results;

--- a/src/simulate/simulateConfig.ts
+++ b/src/simulate/simulateConfig.ts
@@ -1,9 +1,5 @@
-import type { GameConfig } from 'state';
+import type { OverwritableConfig } from 'state';
 
-export const simulateConfig: Pick<
-  GameConfig,
-  'initialScores' | 'trailingRounds'
-> = {
-  initialScores: {},
+export const simulateConfig: OverwritableConfig = {
   trailingRounds: 22,
 };

--- a/src/simulate/simulateConfig.ts
+++ b/src/simulate/simulateConfig.ts
@@ -1,5 +1,19 @@
-import type { OverwritableConfig } from 'state';
+import type { OverwritableConfig } from '../state';
+import type { SimulationWithoutCombinedScore } from './index';
+
+export const STORE_BEST = 5;
+export const STORE_WORST = 5;
 
 export const simulateConfig: OverwritableConfig = {
   trailingRounds: 22,
 };
+
+export const calculateCombinedScore = (sim: SimulationWithoutCombinedScore) => {
+  const normalizedCapacity = sim.final.capacity * 2;
+  const normalizedUserStoryChance =
+    Math.round((sim.final.userStoryChance + 15) / 3) * 2;
+
+  return normalizedCapacity + normalizedUserStoryChance;
+};
+
+export { always3 as actionSelector } from './actionSelectors';

--- a/src/simulate/simulateConfig.ts
+++ b/src/simulate/simulateConfig.ts
@@ -1,0 +1,9 @@
+import type { GameConfig } from 'state';
+
+export const simulateConfig: Pick<
+  GameConfig,
+  'initialScores' | 'trailingRounds'
+> = {
+  initialScores: {},
+  trailingRounds: 22,
+};

--- a/src/simulate/simulateConfig.ts
+++ b/src/simulate/simulateConfig.ts
@@ -1,8 +1,9 @@
 import type { OverwritableConfig } from '../state';
 import type { SimulationWithoutCombinedScore } from './index';
 
-export const STORE_BEST = 5;
-export const STORE_WORST = 5;
+export const INCLUDE_LINK = true;
+export const STORE_BEST = 300;
+export const STORE_WORST = 300;
 
 export const simulateConfig: OverwritableConfig = {
   trailingRounds: 22,

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -75,6 +75,10 @@ export type GameConfig<
   gameEffects: { [key: string]: GameEffect<GameActionId, GremlinId> };
 };
 
+export type OverwritableConfig = Partial<
+  Pick<GameConfig, 'initialScores' | 'trailingRounds'>
+>;
+
 export function getAllEffects<
   GameActionId extends string,
   GremlinId extends string

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -10,6 +10,7 @@ export type {
   GameConfig,
   NextRoundAction,
   RestartGameAction,
+  OverwritableConfig,
 } from './game';
 export type { AppState } from './deriveAppState';
 export type {


### PR DESCRIPTION
<!-- decorate-gh-pr -->
<a href="https://teamsgame.agilepainrelief.com/preview/simulate-more"><img src="https://img.shields.io/badge/published-gh--pages-green" alt="published to gh-pages" /></a><hr />
<!-- /decorate-gh-pr -->

### 1. Switch to node@16

I think its not required that you update node but this also comes with a new major npm version, that uses a different lockfile format. So you'd at least use npm@7 for this. Get it with `npm install -g npm@latest` (Or by updating to npde@16)

### 2. Allow custom number of trailing rounds in simulations 

in `simulateConfig.ts` you can not overwrite a few config parameters. Most notably `trailingRounds` which I've set to `22` so we land at 30 round total with the 8 implemented rounds.

### 3. simulations now always pick 3 actions